### PR TITLE
feat: add trojan source detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ export function runASTAnalysis(str, options = Object.create(null)) {
   });
 
   const sastAnalysis = new Analysis();
+  sastAnalysis.analyzeSourceString(str);
 
   // we walk each AST Nodes, this is a purely synchronous I/O
   walk(body, {

--- a/src/Analysis.js
+++ b/src/Analysis.js
@@ -5,7 +5,7 @@ import { Utils, Literal } from "@nodesecure/sec-literal";
 import { rootLocation, toArrayLocation, generateWarning } from "./utils.js";
 import { warnings as _warnings, processMainModuleRequire } from "./constants.js";
 import ASTDeps from "./ASTDeps.js";
-import { isObfuscatedCode } from "./obfuscators/index.js";
+import { isObfuscatedCode, hasTrojanSource } from "./obfuscators/index.js";
 import { runOnProbes } from "./probes/index.js";
 
 // CONSTANTS
@@ -66,6 +66,12 @@ export default class Analysis {
     this.warnings.push(generateWarning(warningName, { value, location }));
     if (symbol === _warnings.encodedLiteral) {
       this.handledEncodedLiteralValues.set(value, this.warnings.length - 1);
+    }
+  }
+
+  analyzeSourceString(sourceString) {
+    if (hasTrojanSource(sourceString)) {
+      this.addWarning(_warnings.obfuscatedCode, "trojan-source");
     }
   }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,6 +15,25 @@ export const globalIdentifiers = new Set(["global", "globalThis", "root", "GLOBA
  */
 export const globalParts = new Set([...globalIdentifiers, "process", "mainModule", "require"]);
 
+/**
+ * Dangerous Unicode control characters that can be used by hackers
+ * to perform trojan source.
+ */
+export const unsafeUnicodeControlCharacters = [
+  "\u202A",
+  "\u202B",
+  "\u202D",
+  "\u202E",
+  "\u202C",
+  "\u2066",
+  "\u2067",
+  "\u2068",
+  "\u2069",
+  "\u200E",
+  "\u200F",
+  "\u061C"
+];
+
 export const warnings = Object.freeze({
   parsingError: Symbol("ParsingError"),
   unsafeImport: Symbol("UnsafeImport"),

--- a/src/obfuscators/index.js
+++ b/src/obfuscators/index.js
@@ -6,6 +6,7 @@ import * as jjencode from "./jjencode.js";
 import * as jsfuck from "./jsfuck.js";
 import * as freejsobfuscator from "./freejsobfuscator.js";
 import * as obfuscatorio from "./obfuscator-io.js";
+import * as trojan from "./trojan-source.js";
 
 // CONSTANTS
 const kMinimumIdsCount = 5;
@@ -51,6 +52,10 @@ export function isObfuscatedCode(analysis) {
   }
 
   return [encoderName !== null, encoderName];
+}
+
+export function hasTrojanSource(sourceString) {
+  return trojan.verify(sourceString);
 }
 
 function calcAvgPrefixedIdentifiers(analysis, prefix) {

--- a/src/obfuscators/trojan-source.js
+++ b/src/obfuscators/trojan-source.js
@@ -1,0 +1,11 @@
+import { unsafeUnicodeControlCharacters } from "../constants.js";
+
+export function verify(sourceString) {
+  for (const unsafeCharacter of unsafeUnicodeControlCharacters) {
+    if (sourceString.includes(unsafeCharacter)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/test/fixtures/obfuscated/unsafe-unicode-chars.js
+++ b/test/fixtures/obfuscated/unsafe-unicode-chars.js
@@ -1,0 +1,6 @@
+function deleteAccount(role) {
+    if (role === "admin‮ ⁦// Check if admin⁩ ⁦") {
+        // Do Admin-only stuff
+    }
+    return;
+}


### PR DESCRIPTION
Fixes #15 

Standard implementation of the trojan source detection using a list of dangerous Unicode control characters (see more here : [https://www.unicode.org/reports/tr9/](url)).

For now, a warning is collected whenever one of the unsafe control char is found in a source string. Here is an example of the collected warning : 
`{
  kind: 'obfuscated-code',
  location: [ [ 0, 0 ], [ 0, 0 ] ],
  value: 'trojan-source'
}`

The analysis is done directly in a brand new Analysis class method `analyzeSourceString()` that could be used for all checks upstream the Tree walk requiring the whole source string.