### PR TITLE
refactor: enhance parseScript to always support ESM

### DIFF
--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -1,0 +1,13 @@
+// Import Third-party Dependencies
+import test from "tape";
+
+// Import Internal Dependencies
+import { runASTAnalysis } from "../index.js";
+
+test("it should not crash even if module 'false' is provided", (tape) => {
+  runASTAnalysis("import * as foo from \"foo\";", {
+    module: false
+  });
+
+  tape.end();
+});

--- a/test/regress.spec.js
+++ b/test/regress.spec.js
@@ -6,7 +6,6 @@ import test from "tape";
 
 // Import Internal Dependencies
 import { runASTAnalysis } from "../index.js";
-import { getWarningKind } from "./utils/index.js";
 
 // CONSTANTS
 const FIXTURE_URL = new URL("fixtures/regress/", import.meta.url);


### PR DESCRIPTION
Always support parsing of ESM even if `module` false is provided to JS-X-Ray.