### PR TITLE
feat: add removeHTMLComments option

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ This section describe all the possible warnings returned by JSXRay. Click on the
 
 ```ts
 interface RuntimeOptions {
-    module?: boolean;
-    isMinified?: boolean;
+  module?: boolean;
+  isMinified?: boolean;
+  removeHTMLComments?: boolean;
 }
 ```
 
@@ -156,11 +157,11 @@ The method take a first argument which is the code you want to analyse. It will 
 
 ```ts
 interface Report {
-    dependencies: ASTDeps;
-    warnings: Warning[];
-    idsLengthAvg: number;
-    stringScore: number;
-    isOneLineRequire: boolean;
+  dependencies: ASTDeps;
+  warnings: Warning[];
+  idsLengthAvg: number;
+  stringScore: number;
+  isOneLineRequire: boolean;
 }
 ```
 
@@ -171,8 +172,9 @@ interface Report {
 
 ```ts
 interface RuntimeOptions {
-    module?: boolean;
-    isMinified?: boolean;
+  module?: boolean;
+  isMinified?: boolean;
+  removeHTMLComments?: boolean;
 }
 ```
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,3 +42,7 @@ export function extractNode(expectedType) {
     }
   };
 }
+
+export function removeHTMLComment(str) {
+  return str.replace(/<!--[\s\S]*?(?:-->)/g, "");
+}

--- a/test/fixtures/regress/html-comments.js
+++ b/test/fixtures/regress/html-comments.js
@@ -1,0 +1,9 @@
+<!-- const foo = 5; //-->;
+
+var bar;
+
+<!--
+// == fake comment == //
+
+const yo = 5;
+//-->;

--- a/test/regress.spec.js
+++ b/test/regress.spec.js
@@ -24,3 +24,26 @@ test("it should not crash for JSX", (tape) => {
 
   tape.end();
 });
+
+// Regression test for https://github.com/NodeSecure/js-x-ray/issues/109
+test("it should not crash for a JavaScript file containing HTML comments (and removeHTMLComments option enabled)", (tape) => {
+  const htmlComment = readFileSync(new URL("html-comments.js", FIXTURE_URL), "utf-8");
+  runASTAnalysis(htmlComment, {
+    removeHTMLComments: true
+  });
+
+  tape.end();
+});
+
+test("it should crash for a JavaScript file containing HTML comments", (tape) => {
+  const htmlComment = readFileSync(new URL("html-comments.js", FIXTURE_URL), "utf-8");
+  try {
+    runASTAnalysis(htmlComment);
+    tape.fail();
+  }
+  catch {
+    // do nothing
+  }
+
+  tape.end();
+});

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,0 +1,27 @@
+// Import Third-party Dependencies
+import test from "tape";
+
+// Import Internal Dependencies
+import { removeHTMLComment } from "../src/utils.js";
+
+test("removeHTMLComment() function should remove singleline HTML comment from string", (tape) => {
+  const result = removeHTMLComment(`
+    <!-- const yo = 5; -->
+  `);
+  tape.strictEqual(result.trim(), "");
+
+  tape.end();
+});
+
+test("removeHTMLComment() function should remove multiline HTML comment from string", (tape) => {
+  const result = removeHTMLComment(`
+    <!--
+  // == fake comment == //
+
+  const yo = 5;
+  //-->
+  `);
+  tape.strictEqual(result.trim(), "");
+
+  tape.end();
+});

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -13,8 +13,18 @@ export {
 }
 
 interface RuntimeOptions {
+  /**
+   * @default true
+   */
   module?: boolean;
+  /**
+   * @default false
+   */
   isMinified?: boolean;
+  /**
+   * @default false
+   */
+  removeHTMLComments?: boolean;
 }
 
 interface Report {
@@ -27,7 +37,14 @@ interface Report {
 
 interface RuntimeFileOptions {
   packageName?: string;
+  /**
+   * @default true
+   */
   module?: boolean;
+  /**
+   * @default false
+   */
+  removeHTMLComments?: boolean;
 }
 
 type ReportOnFile = {


### PR DESCRIPTION
Add a new option `removeHTMLComments` to remove any HTML comment from the provided source (or file).

Adding this as an option disabled by default because I'm not quite sure of the impact of this (and if this could be exploited in someway).

Should fixes #109