### PR TITLE
fix: broken morse detection

### DIFF
--- a/src/Analysis.js
+++ b/src/Analysis.js
@@ -88,7 +88,7 @@ export default class Analysis {
     }
 
     // Searching for morse string like "--.- --.--."
-    if (Utils.stringCharDiversity(str, ["\n"]) >= 3 && Utils.isMorse(str)) {
+    if (Utils.isMorse(str)) {
       this.counter.morseLiteral++;
     }
   }

--- a/src/obfuscators/index.js
+++ b/src/obfuscators/index.js
@@ -37,11 +37,6 @@ export function isObfuscatedCode(analysis) {
     if (analysis.counter.identifiers > kMinimumIdsCount && uPrefixNames.size > 0) {
       analysis.hasPrefixedIdentifiers = calcAvgPrefixedIdentifiers(analysis, prefix) > 80;
     }
-    // console.log(prefix);
-    // console.log(oneTimeOccurence);
-    // console.log(analysis.hasPrefixedIdentifiers);
-    // console.log(analysis.counter.identifiers);
-    // console.log(analysis.counter.encodedArrayValue);
 
     if (uPrefixNames.size === 1 && freejsobfuscator.verify(analysis, prefix)) {
       encoderName = "freejsobfuscator";

--- a/test/fixtures/obfuscated/notMorse.js
+++ b/test/fixtures/obfuscated/notMorse.js
@@ -1,0 +1,62 @@
+function decodeNotMorse(notMorseCode) {
+    var ref = {
+        '.': 'a',
+        '..': 'b',
+        '...': 'c',
+        '-': 'd',
+        '--': 'e',
+        '---': 'f',
+        '.-': 'g',
+        '.--': 'h',
+        '-.': 'i',
+        '-..': 'j',
+        '....': 'k',
+        '----': 'l',
+        '.-.-': 'm',
+        '.--.': 'n',
+        '....----': 'o',
+        '...----': 'p',
+        '..----': 'q',
+        '.----': 'r',
+        '. . .': 's',
+        '- - -': 't',
+        '. - .': 'u',
+        '- . -': 'v',
+        '. . -': 'w',
+        '- . .': 'x',
+        '- - .': 'y',
+        '_': 'z',
+        '__': '1',
+        '___': '2',
+        '____': '3',
+        '._': '4',
+        '.__': '5',
+        '.___': '6',
+        '__.': '7',
+        '.-_': '8',
+        '-._': '9',
+        '_-.': '0',
+    };
+
+    return notMorseCode
+        .split('   ')
+        .map(
+            a => a
+                .split(' ')
+                .map(
+                    b => ref[b]
+                ).join('')
+        ).join(' ');
+}
+
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+var decoded = decodeNotMorse(".-- --- .-. -..   .-- --- .-. -..");
+console.log(decoded);

--- a/test/obfuscated.spec.js
+++ b/test/obfuscated.spec.js
@@ -20,14 +20,21 @@ test("should detect 'jsfuck' obfuscation", () => {
   assert.strictEqual(warnings[0].value, "jsfuck");
 });
 
-// test("should detect 'morse' obfuscation", () => {
-//   const trycatch = readFileSync(new URL("morse.js", FIXTURE_URL), "utf-8");
-//   const { warnings } = runASTAnalysis(trycatch);
+test("should detect 'morse' obfuscation", () => {
+  const trycatch = readFileSync(new URL("morse.js", FIXTURE_URL), "utf-8");
+  const { warnings } = runASTAnalysis(trycatch);
 
-//   assert.strictEqual(warnings.length, 1);
-//   assert.deepEqual(getWarningKind(warnings), ["obfuscated-code"].sort());
-//   assert.strictEqual(warnings[0].value, "morse");
-// });
+  assert.strictEqual(warnings.length, 1);
+  assert.deepEqual(getWarningKind(warnings), ["obfuscated-code"].sort());
+  assert.strictEqual(warnings[0].value, "morse");
+});
+
+test("should not detect 'morse' obfuscation", () => {
+  const trycatch = readFileSync(new URL("notMorse.js", FIXTURE_URL), "utf-8");
+  const { warnings } = runASTAnalysis(trycatch);
+
+  assert.strictEqual(warnings.length, 0);
+});
 
 test("should detect 'jjencode' obfuscation", () => {
   const trycatch = readFileSync(


### PR DESCRIPTION
This PR fixes #144 

The stringCharDiversity was breaking the test (and the analysis), in the `morse.js` fixture, we have somethings like:
- `’.-‘: ‘a’,` -> here, stringCharDiversity is 2 
- `’-…’: ‘b’,` -> stringCharDiversity is 2 
- `’-.-.’: ‘c’,` -> stringCharDiversity is 2 
- `’-..’: ‘d’,` ->stringCharDiversity is 2 
-  `’.’: ‘e’,` ->  stringCharDiversity is 1
- `’..-.’: ‘f’,` -> stringCharDiversity is 2 
- etc  

Actually  the total counter of morseLiteral in the `morse.js` fixture is **37**, which match: 
```js
else if (analysis.counter.morseLiteral >= 36) {
  encoderName = "morse";
}
```

That’s why I think this fix is fine.

I’ve also added a "not morse" detection test, I’m not sure about this test plus-value and the fixture’s accuracy but it should test there is no abuse with theses changes.
