### PR TITLE
fix the example in readme to prevent "location" field displays wrong way when running as script with Node.js. (nested displayed as [Array])

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ console.log(dependenciesName);
 console.log(inTryDeps);
 console.log(warnings);
 ```
+---
+
+If you meant to run this example with Node.js quickly in terminal, use this example below to correctly display the ``location`` field.
+```js
+import { runASTAnalysis } from "@nodesecure/js-x-ray";
+import { readFileSync } from "fs";
+
+const str = readFileSync("./file.js", "utf-8");
+const { warnings, dependencies } = runASTAnalysis(str);
+
+const dependenciesName = [...dependencies];
+const inTryDeps = [...dependencies.getDependenciesInTryStatement()];
+
+console.log(dependenciesName);
+console.log(inTryDeps);
+console.log(JSON.stringify(warnings, null, 2));
+```
+save content above to a ``.mjs`` file and run it with this command in your terminal``
+node ./example_filename.mjs``
+
+---
 
 The analysis will return: `http` (in try), `crypto`, `util` and `fs`.
 

--- a/README.md
+++ b/README.md
@@ -78,29 +78,8 @@ const inTryDeps = [...dependencies.getDependenciesInTryStatement()];
 
 console.log(dependenciesName);
 console.log(inTryDeps);
-console.log(warnings);
+console.dir(warnings, { depth: null });
 ```
----
-
-If you meant to run this example with Node.js quickly in terminal, use this example below to correctly display the ``location`` field.
-```js
-import { runASTAnalysis } from "@nodesecure/js-x-ray";
-import { readFileSync } from "fs";
-
-const str = readFileSync("./file.js", "utf-8");
-const { warnings, dependencies } = runASTAnalysis(str);
-
-const dependenciesName = [...dependencies];
-const inTryDeps = [...dependencies.getDependenciesInTryStatement()];
-
-console.log(dependenciesName);
-console.log(inTryDeps);
-console.log(JSON.stringify(warnings, null, 2));
-```
-save content above to a ``.mjs`` file and run it with this command in your terminal``
-node ./example_filename.mjs``
-
----
 
 The analysis will return: `http` (in try), `crypto`, `util` and `fs`.
 


### PR DESCRIPTION
this PR fix the example in readme to prevent "location" field displays wrong way when running as script with Node.js. (nested displayed as [Array])  
Since this repo doesn't have a "dev" branch and i don't have permission to this repo to push more branches, this PR directly pointed to master/main branch. If i need to change it, feel free to ask me to do so.  
Thx