### PR TITLE
docs: estree-ast-utils typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Click on one of the links to access the documentation of the workspace:
 
 | name | package and link |
 | --- | --- |
-| estree-ast-util | [@nodesecure/estree-ast-util](./workspaces/estree-ast-util) |
+| estree-ast-utils | [@nodesecure/estree-ast-utils](./workspaces/estree-ast-utils) |
 | sec-literal | [@nodesecure/sec-literal ](./workspaces/sec-literal) |
 
 These packages are available in the Node Package Repository and can be easily installed with [npm](https://docs.npmjs.com/getting-started/what-is-npm) or [yarn](https://yarnpkg.com).


### PR DESCRIPTION
The link redirected to 404