### PR TITLE
feat(probeRunner): assert probes method in proberunner

### DIFF
--- a/src/ProbeRunner.js
+++ b/src/ProbeRunner.js
@@ -1,3 +1,6 @@
+// Import Native Dependencies
+import assert from "node:assert";
+
 // Import all the probes
 import isUnsafeCallee from "./probes/isUnsafeCallee.js";
 import isLiteral from "./probes/isLiteral.js";
@@ -71,7 +74,17 @@ export class ProbeRunner {
   ) {
     this.sourceFile = sourceFile;
 
-    // TODO: Assert/validate all probes? (Good first issue)
+    for (const probe of probes) {
+      assert(
+        typeof probe.validateNode === "function" || Array.isArray(probe.validateNode),
+        `Invalid probe ${probe.name}: validateNode must be a function or an array of functions`
+      );
+      assert(
+        typeof probe.main === "function",
+        `Invalid probe ${probe.name}: main must be a function`
+      );
+    }
+
     this.probes = probes;
   }
 

--- a/test/ProbeRunner.spec.js
+++ b/test/ProbeRunner.spec.js
@@ -14,12 +14,57 @@ describe("ProbeRunner", () => {
       assert.strictEqual(pr.probes, ProbeRunner.Defaults);
     });
 
-    it("should use provided probes", () => {
-      const probes = [{}];
+    it("should use provided probes with validate node as func", () => {
+      const fakeProbe = [
+        {
+          validateNode: (node) => [node.type === "CallExpression"],
+          main: mock.fn(),
+          teardown: mock.fn()
+        }
+      ];
 
-      const pr = new ProbeRunner(null, probes);
+      const pr = new ProbeRunner(null, fakeProbe);
       assert.strictEqual(pr.sourceFile, null);
-      assert.strictEqual(pr.probes, probes);
+      assert.strictEqual(pr.probes, fakeProbe);
+    });
+
+    it("should use provided probe with validate node as Array", () => {
+      const fakeProbe = [
+        {
+          validateNode: [],
+          main: mock.fn(),
+          teardown: mock.fn()
+        }];
+
+      const pr = new ProbeRunner(null, fakeProbe);
+      assert.strictEqual(pr.sourceFile, null);
+      assert.strictEqual(pr.probes, fakeProbe);
+    });
+
+    it("should fail if main not present", () => {
+      const fakeProbe = {
+        validateNode: (node) => [node.type === "CallExpression"],
+        teardown: mock.fn()
+      };
+
+      function instantiateProbeRunner() {
+        return new ProbeRunner(null, [fakeProbe]);
+      }
+
+      assert.throws(instantiateProbeRunner, Error, "Invalid probe");
+    });
+
+    it("should fail if validate not present", () => {
+      const fakeProbe = {
+        main: mock.fn(),
+        teardown: mock.fn()
+      };
+
+      function instantiateProbeRunner() {
+        return new ProbeRunner(null, [fakeProbe]);
+      }
+
+      assert.throws(instantiateProbeRunner, Error, "Invalid probe");
     });
   });
 


### PR DESCRIPTION
// TODO: https://github.com/NodeSecure/js-x-ray/blob/master/src/ProbeRunner.js#L74

### Assert probes method in probeRunner constructor

Purpose of this PR is to : 

- [x] assert that validateNode is a function or array of functions
- [x] assert that main is a function
- [x] add unittest

Note that i have used `import assert from "node:assert";` in probeRunner class but same can be done using if conditional.
LMK if it seems ok and enough to cover this TODO in probeRunner class ? I can assert that name exist as well ?

If anyone want to participate/feedback/propose/improve solution don't hesitate!