### PR TITLE
build path.join called in require if args are string literals

### DIFF
--- a/src/probes/isRequire.js
+++ b/src/probes/isRequire.js
@@ -1,4 +1,6 @@
 /* eslint-disable consistent-return */
+// Import Node.js Dependencies
+import path from "node:path";
 
 // Import Third-party Dependencies
 import { Hex } from "@nodesecure/sec-literal";
@@ -11,7 +13,6 @@ import {
   getCallExpressionArguments
 } from "@nodesecure/estree-ast-utils";
 import { ProbeSignals } from "../ProbeRunner.js";
-import path from "path";
 
 function validateNodeRequire(node, { tracer }) {
   const id = getCallExpressionIdentifier(node, {

--- a/src/probes/isRequire.js
+++ b/src/probes/isRequire.js
@@ -1,4 +1,5 @@
 /* eslint-disable consistent-return */
+
 // Import Node.js Dependencies
 import path from "node:path";
 

--- a/test/issues/178-path-join-literal-args-is-not-unsafe.spec.js
+++ b/test/issues/178-path-join-literal-args-is-not-unsafe.spec.js
@@ -13,7 +13,7 @@ const validTestCases = [
   "const bin = require.resolve(path.join('..', './bin.js'));"
 ];
 
-test("should not detect unsafe-import of path.join every argument is a Literal string", () => {
+test("should not detect unsafe-import for path.join if every argument is a string literal", () => {
   validTestCases.forEach((test) => {
     const { warnings, dependencies } = runASTAnalysis(test);
 
@@ -29,7 +29,7 @@ const invalidTestCases = [
   "const bin = require.resolve(path.join(3, '..', './bin.js'));"
 ];
 
-test("should detect unsafe-import of path.join if not every argument is a Literal string", () => {
+test("should detect unsafe-import of path.join if not every argument is a string literal", () => {
   invalidTestCases.forEach((test) => {
     const { warnings } = runASTAnalysis(test);
 

--- a/test/issues/178-path-join-literal-args-is-not-unsafe.spec.js
+++ b/test/issues/178-path-join-literal-args-is-not-unsafe.spec.js
@@ -1,0 +1,39 @@
+// Import Node.js Dependencies
+import { test } from "node:test";
+import assert from "node:assert";
+
+// Import Internal Dependencies
+import { runASTAnalysis } from "../../index.js";
+
+/**
+ * @see https://github.com/NodeSecure/js-x-ray/issues/178
+ */
+
+const validTestCases = [
+  "const bin = require(path.join('..', './bin.js'));",
+  "const bin = require.resolve(path.join('..', './bin.js'));"
+];
+
+test("should not detect unsafe-import of path.join every argument is a Literal string", () => {
+  validTestCases.forEach((test) => {
+    const { warnings, dependencies } = runASTAnalysis(test);
+
+    assert.strictEqual(warnings.length, 0);
+    assert.ok(dependencies.has("../bin.js"));
+  });
+});
+
+const invalidTestCases = [
+  "const bin = require(path.join(__dirname, '..', './bin.js'));",
+  "const bin = require(path.join(3, '..', './bin.js'));",
+  "const bin = require.resolve(path.join(__dirname, '..', './bin.js'));",
+  "const bin = require.resolve(path.join(3, '..', './bin.js'));"
+];
+
+test("should detect unsafe-import of path.join if not every argument is a Literal string", () => {
+  invalidTestCases.forEach((test) => {
+    const { warnings } = runASTAnalysis(test);
+
+    assert.strictEqual(warnings.length, 1);
+  });
+});

--- a/test/issues/178-path-join-literal-args-is-not-unsafe.spec.js
+++ b/test/issues/178-path-join-literal-args-is-not-unsafe.spec.js
@@ -8,7 +8,6 @@ import { runASTAnalysis } from "../../index.js";
 /**
  * @see https://github.com/NodeSecure/js-x-ray/issues/178
  */
-
 const validTestCases = [
   "const bin = require(path.join('..', './bin.js'));",
   "const bin = require.resolve(path.join('..', './bin.js'));"


### PR DESCRIPTION
This PR addresses partially issue [ #178](https://github.com/NodeSecure/js-x-ray/issues/178).

If `path.join` is called in `require` and every argument is a string literal:
```js
const bin = require(path.join('.', 'bin.js'))
```
The dependency is normalized an no unsafe-import warning is triggered.
