### PR TITLE
[WIP] Rework sourcefile analysis strategy

### DIFF
--- a/src/AstAnalyser.js
+++ b/src/AstAnalyser.js
@@ -16,9 +16,10 @@ export class AstAnalyser {
    * @constructor
    * @param { SourceParser } [parser]
    */
-  constructor(parser = new JsSourceParser()) {
+  constructor(parser = new JsSourceParser(), entryFiles = []) {
     this.parser = parser;
     this.analyzedFiles = new Map();
+    this.entryFiles = entryFiles.map((entry) => path.resolve(entry));
   }
 
   reset() {
@@ -69,6 +70,11 @@ export class AstAnalyser {
 
     if (this.analyzedFiles.has(filePathString)) {
       return this.analyzedFiles.get(filePathString);
+    }
+
+    const toSkip = this.#toSkip(filePathString);
+    if (toSkip) {
+      return { ok: true, isSkipped: true };
     }
 
     try {
@@ -140,5 +146,19 @@ export class AstAnalyser {
    */
   #removeHTMLComment(str) {
     return str.replaceAll(/<!--[\s\S]*?(?:-->)/g, "");
+  }
+
+  #toSkip(filePathString) {
+    if (!this.entryFiles.length) {
+      return false;
+    }
+
+    for (const dir of this.entryFiles) {
+      if (filePathString.startsWith(dir)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/test/AstAnalyser.spec.js
+++ b/test/AstAnalyser.spec.js
@@ -198,6 +198,44 @@ describe("AstAnalyser", (t) => {
     assert.strictEqual(calls.length, 2);
   });
 
+  it("should skip files that are not part of entry files", async(t) => {
+    const FIXTURE_URL = new URL("fixtures/entryFiles/", import.meta.url);
+
+    const analyser = new AstAnalyser(new JsSourceParser(), [
+      "test/fixtures/entryFiles/src",
+      "test/fixtures/entryFiles/src2"
+    ]);
+
+    const validTestFiles = [
+      "src/foo.js",
+      "src/bar/bar.js",
+      "src2/foo.js",
+      "src2/bar/bar.js"
+    ];
+
+    validTestFiles.forEach(async(file) => {
+      const result = await analyser.analyseFile(
+        new URL(file, FIXTURE_URL)
+      );
+
+      assert.ok(result.ok);
+    });
+
+    const invalidTestFiles = [
+      "test/foo.js",
+      "test/bar/bar.js"
+    ];
+
+    invalidTestFiles.forEach(async(file) => {
+      const result = await analyser.analyseFile(
+        new URL(file, FIXTURE_URL)
+      );
+
+      assert.ok(result.ok);
+      assert.ok(result.isSkipped);
+    });
+  });
+
   it("should fail with a parsing error", async() => {
     const result = await getAnalyser().analyseFile(
       new URL("parsingError.js", FIXTURE_URL),

--- a/test/AstAnalyser.spec.js
+++ b/test/AstAnalyser.spec.js
@@ -186,7 +186,7 @@ describe("AstAnalyser", (t) => {
     let calls = AstAnalyser.prototype.analyse.mock.calls;
     assert.strictEqual(calls.length, 1);
 
-    // should remove the cache and call AstAnalyser.analyse again
+    // should remove the cache
     analyser.reset();
 
     await analyser.analyseFile(

--- a/test/fixtures/entryFiles/src/bar/bar.js
+++ b/test/fixtures/entryFiles/src/bar/bar.js
@@ -1,0 +1,1 @@
+require("foobar");

--- a/test/fixtures/entryFiles/src/foo.js
+++ b/test/fixtures/entryFiles/src/foo.js
@@ -1,0 +1,1 @@
+require("foobar");

--- a/test/fixtures/entryFiles/src2/bar/bar.js
+++ b/test/fixtures/entryFiles/src2/bar/bar.js
@@ -1,0 +1,1 @@
+require("foobar");

--- a/test/fixtures/entryFiles/src2/foo.js
+++ b/test/fixtures/entryFiles/src2/foo.js
@@ -1,0 +1,1 @@
+require("foobar");

--- a/test/fixtures/entryFiles/test/bar/bar.js
+++ b/test/fixtures/entryFiles/test/bar/bar.js
@@ -1,0 +1,1 @@
+require("foobar");

--- a/test/fixtures/entryFiles/test/foo.js
+++ b/test/fixtures/entryFiles/test/foo.js
@@ -1,0 +1,1 @@
+require("foobar");


### PR DESCRIPTION
Fixes #237 

It's still a WIP.
I don't know if this is what you were thinking @fraxken ....

I'd like to allow the use of blobs: 
```js
["src/**/*", "tests/**/*"]
```

I'll adapt the code when [Tchapacan PR](https://github.com/NodeSecure/js-x-ray/pull/250) is merged.