### PR TITLE
fix: change builtinModules import from repl to module

### DIFF
--- a/src/probes/isLiteral.js
+++ b/src/probes/isLiteral.js
@@ -1,5 +1,5 @@
 // Import Node.js Dependencies
-import { builtinModules } from "repl";
+import { builtinModules } from "module";
 
 // Import Third-party Dependencies
 import { Hex } from "@nodesecure/sec-literal";


### PR DESCRIPTION
According to [Node.js deprecation notice DEP0191](https://nodejs.org/api/deprecations.html#dep0191-replbuiltinmodules), the `repl.builtinModules` property is deprecated as of Node.js v24.0.0:

> The `node:repl` module exports a `builtinModules` property that contains an array of built-in modules. This was incomplete and matched the already deprecated `repl._builtinLibs` (DEP0142) instead it's better to rely upon `require('node:module').builtinModules`.

## Changes
- Changed import from `import { builtinModules } from "repl";` to `import { builtinModules } from "module";`