### PR TITLE
feat(probes): add isUnsafeSpawn

### DIFF
--- a/docs/unsafe-spawn.md
+++ b/docs/unsafe-spawn.md
@@ -1,0 +1,1 @@
+# Unsafe spawn

--- a/src/ProbeRunner.js
+++ b/src/ProbeRunner.js
@@ -13,6 +13,7 @@ import isBinaryExpression from "./probes/isBinaryExpression.js";
 import isArrayExpression from "./probes/isArrayExpression.js";
 import isESMExport from "./probes/isESMExport.js";
 import isFetch from "./probes/isFetch.js";
+import isUnsafeSpawn from "./probes/isUnsafeSpawn.js"
 
 // Import Internal Dependencies
 import { SourceFile } from "./SourceFile.js";
@@ -50,7 +51,8 @@ export class ProbeRunner {
     isImportDeclaration,
     isWeakCrypto,
     isBinaryExpression,
-    isArrayExpression
+    isArrayExpression,
+    isUnsafeSpawn
   ];
 
   /**

--- a/src/probes/isUnsafeSpawn.js
+++ b/src/probes/isUnsafeSpawn.js
@@ -1,0 +1,69 @@
+// Import Internal Dependencies
+import { getCallExpressionIdentifier } from "@nodesecure/estree-ast-utils";
+import { ProbeSignals } from "../ProbeRunner.js";
+
+/**
+ * @description Detect spawn commands containing csrutil
+ * @example
+ * child_process.spawn("csrutil", ["status"]);
+ * require("child_process").spawn("csrutil", ["disable"]);
+ * const { spawn } = require("child_process");
+ * spawn("csrutil", ["status"]);
+ */
+function validateNode(node, { tracer }) {
+  if (node.type !== "CallExpression" || node.arguments.length === 0) {
+    return [false];
+  }
+
+  // Direct: child_process.spawn(...) or require("child_process").spawn(...)
+  if (
+    node.callee.type === "MemberExpression" &&
+    node.callee.property.type === "Identifier" &&
+    node.callee.property.name === "spawn"
+  ) {
+    // child_process.spawn(...)
+    if (
+      node.callee.object.type === "Identifier" &&
+      node.callee.object.name === "child_process"
+    ) {
+      return [true];
+    }
+    // require("child_process").spawn(...)
+    if (
+      node.callee.object.type === "CallExpression" &&
+      node.callee.object.callee.type === "Identifier" &&
+      node.callee.object.callee.name === "require" &&
+      node.callee.object.arguments.length === 1 &&
+      node.callee.object.arguments[0].type === "Literal" &&
+      node.callee.object.arguments[0].value === "child_process"
+    ) {
+      return [true];
+    }
+  }
+
+  return [false];
+}
+
+function main(node, options) {
+  const { sourceFile } = options;
+
+  // Get the first argument of spawn which should be the command
+  const commandArg = node.arguments[0];
+  if (!commandArg || commandArg.type !== "Literal") {
+    return null;
+  }
+
+  const command = commandArg.value;
+  if (typeof command === "string" && command.includes("csrutil")) {
+    sourceFile.addWarning("unsafe-spawn", command, node.loc);
+    return ProbeSignals.Skip;
+  }
+
+  return null;
+}
+
+export default {
+  name: "isUnsafeSpwan",
+  validateNode,
+  main
+};

--- a/src/warnings.js
+++ b/src/warnings.js
@@ -50,6 +50,11 @@ export const warnings = Object.freeze({
     i18n: "sast_warnings.shady_link",
     severity: "Warning",
     experimental: false
+  },
+  "unsafe-spawn": {
+    i18n: "sast_warnings.unsafe-spawn",
+    severity: "Warning",
+    experimental: true
   }
 });
 

--- a/test/probes/isUnsafeSpawn.spec.js
+++ b/test/probes/isUnsafeSpawn.spec.js
@@ -1,0 +1,52 @@
+// Import Node.js dependencies
+import { test } from "node:test";
+import assert from "node:assert";
+
+// Import Internal Dependencies
+import { parseScript, getSastAnalysis } from "../utils/index.js";
+import isUnsafeSpawn from "../../src/probes/isUnsafeSpawn.js";
+
+// CONSTANTS
+const kWarningUnsafeSpawn = "unsafe-spawn";
+
+// test("should detect csrutil spawn command", () => {
+//   const str = `
+//     const { spawn } = require("child_process");
+//     spawn("csrutil", ["status"]);
+//   `;
+//
+//   const ast = parseScript(str);
+//   const sastAnalysis = getSastAnalysis(str, isUnsafeSpawn)
+//     .execute(ast.body);
+//
+//   const result = sastAnalysis.getWarning(kWarningUnsafeSpawn);
+//   assert.equal(result.kind, kWarningUnsafeSpawn);
+//   assert.equal(result.value, "csrutil");
+// });
+
+test("should detect csrutil spawn command with require", () => {
+  const str = `
+    require("child_process").spawn("csrutil", ["disable"]);
+  `;
+
+  const ast = parseScript(str);
+  const sastAnalysis = getSastAnalysis(str, isUnsafeSpawn)
+    .execute(ast.body);
+
+  const result = sastAnalysis.getWarning(kWarningUnsafeSpawn);
+  assert.equal(result.kind, kWarningUnsafeSpawn);
+  assert.equal(result.value, "csrutil");
+});
+
+test("should not detect non-csrutil spawn command", () => {
+  const str = `
+    const { spawn } = require("child_process");
+    spawn("ls", ["-la"]);
+  `;
+
+  const ast = parseScript(str);
+  const sastAnalysis = getSastAnalysis(str, isUnsafeSpawn)
+    .execute(ast.body);
+
+  assert.equal(sastAnalysis.warnings().length, 0);
+});

--- a/types/warnings.d.ts
+++ b/types/warnings.d.ts
@@ -16,7 +16,8 @@ type WarningNameWithValue = "parsing-error"
 | "suspicious-file"
 | "obfuscated-code"
 | "weak-crypto"
-| "shady-link";
+| "shady-link"
+| "unsafe-spwan";
 type WarningName = WarningNameWithValue | "unsafe-import";
 
 type WarningLocation = [[number, number], [number, number]];


### PR DESCRIPTION
I would like to introduce `isUnsafeSpwan` probe.

I had the idea earlier in the day reading a book on macOS malware where authors try to detect if SIP is enabled (`csrutil`).

I noticed a bunch of commands that could be suspicious if passed in spawn/exec.

I imaged something where we could have a bunch of specific command we could mark as suspicious.

My concerns is "What about false positives?" Maybe we would like to have a probe that could take a list of commands and add warnings only for these cases.
