### PR TITLE
feat(AstAnalyser): add SourceFlags with oneline-require and is-minified

### DIFF
--- a/docs/api/AstAnalyser.md
+++ b/docs/api/AstAnalyser.md
@@ -73,7 +73,7 @@ interface RuntimeOptions {
   finalize?: (sourceFile: SourceFile) => void;
 }
 
-type SourceFlags = "fetch";
+type SourceFlags = "fetch" | "oneline-require" | "is-minified";
 
 interface Report {
   dependencies: Map<string, Dependency>;
@@ -81,7 +81,6 @@ interface Report {
   flags: Set<SourceFlags>;
   idsLengthAvg: number;
   stringScore: number;
-  isOneLineRequire: boolean;
 }
 
 type ReportOnFile = {
@@ -89,7 +88,6 @@ type ReportOnFile = {
   warnings: Warning[];
   flags: Set<SourceFlags>;
   dependencies: Map<string, Dependency>;
-  isMinified: boolean;
 } | {
   ok: false,
   warnings: Warning[];
@@ -101,6 +99,8 @@ A given SourceFile can have multiple unique flags:
 | name | description |
 | --- | --- |
 | fetch | the source file include at least one [native fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) CallExpression |
+| oneline-require | the source file is a one-line require expression (like `module.exports = require('foo')`) |
+| is-minified | the source file is detected as minified |
 
 ### Hooks
 

--- a/src/AstAnalyser.js
+++ b/src/AstAnalyser.js
@@ -75,11 +75,15 @@ export class AstAnalyser {
       finalize(source);
     }
 
+    // Add oneline-require flag if this is a one-line require expression
+    if (isOneLineExpressionExport(body)) {
+      source.flags.add("oneline-require");
+    }
+
     return {
       ...source.getResult(isMinified),
       dependencies: source.dependencies,
-      flags: source.flags,
-      isOneLineRequire: isOneLineExpressionExport(body)
+      flags: source.flags
     };
   }
 
@@ -112,12 +116,16 @@ export class AstAnalyser {
         data.dependencies.delete(packageName);
       }
 
+      // Add is-minified flag if the file is minified and not a one-line require
+      if (!data.flags.has("oneline-require") && isMin) {
+        data.flags.add("is-minified");
+      }
+
       return {
         ok: true,
         dependencies: data.dependencies,
         warnings: data.warnings,
-        flags: data.flags,
-        isMinified: !data.isOneLineRequire && isMin
+        flags: data.flags
       };
     }
     catch (error) {
@@ -159,11 +167,16 @@ export class AstAnalyser {
         data.dependencies.delete(packageName);
       }
 
+      // Add is-minified flag if the file is minified and not a one-line require
+      if (!data.flags.has("oneline-require") && isMin) {
+        data.flags.add("is-minified");
+      }
+
       return {
         ok: true,
         dependencies: data.dependencies,
         warnings: data.warnings,
-        isMinified: !data.isOneLineRequire && isMin
+        flags: data.flags
       };
     }
     catch (error) {

--- a/test/AstAnalyser.spec.js
+++ b/test/AstAnalyser.spec.js
@@ -133,11 +133,11 @@ describe("AstAnalyser", (t) => {
     });
 
     it("should return isOneLineRequire true given a single line CJS export", () => {
-      const { dependencies, isOneLineRequire } = getAnalyser().analyse(
+      const { dependencies, flags } = getAnalyser().analyse(
         "module.exports = require('foo');"
       );
 
-      assert.ok(isOneLineRequire);
+      assert.ok(flags.has("oneline-require"));
       assert.deepEqual([...dependencies.keys()], ["foo"]);
     });
 

--- a/test/issues/170-isOneLineRequire-logicalExpression-CJS-export.spec.js
+++ b/test/issues/170-isOneLineRequire-logicalExpression-CJS-export.spec.js
@@ -37,9 +37,9 @@ const validTestCases = [
 test("it should return isOneLineRequire true given a single line CJS export with a valid assignment", () => {
   validTestCases.forEach((test) => {
     const [source, modules] = test;
-    const { dependencies, isOneLineRequire } = new AstAnalyser().analyse(source);
+    const { dependencies, flags } = new AstAnalyser().analyse(source);
 
-    assert.ok(isOneLineRequire);
+    assert.ok(flags.has("oneline-require"));
     assert.deepEqual([...dependencies.keys()], modules);
   });
 });
@@ -60,9 +60,9 @@ const invalidTestCases = [
 test("it should return isOneLineRequire false given a single line CJS export with illegal callees", () => {
   invalidTestCases.forEach((test) => {
     const [source, modules] = test;
-    const { dependencies, isOneLineRequire } = new AstAnalyser().analyse(source);
+    const { dependencies, flags } = new AstAnalyser().analyse(source);
 
-    assert.ok(isOneLineRequire === false);
+    assert.ok(flags.has("oneline-require") === false);
     assert.deepEqual([...dependencies.keys()], modules);
   });
 });

--- a/test/issues/283-oneline-require-minified.spec.js
+++ b/test/issues/283-oneline-require-minified.spec.js
@@ -7,13 +7,13 @@ import { AstAnalyser } from "../../index.js";
 
 // Regression test for https://github.com/NodeSecure/js-x-ray/issues/283
 test("Given a one line require (with no module.exports) then isOneLineRequire must equal true", () => {
-  const { isOneLineRequire } = new AstAnalyser().analyse(`require('foo.js');`);
+  const { flags } = new AstAnalyser().analyse("require('foo.js');");
 
-  assert.ok(isOneLineRequire);
+  assert.ok(flags.has("oneline-require"));
 });
 
 test("Given an empty code then isOneLineRequire must equal false", () => {
-  const { isOneLineRequire } = new AstAnalyser().analyse(``);
+  const { flags } = new AstAnalyser().analyse("");
 
-  assert.strictEqual(isOneLineRequire, false);
+  assert.strictEqual(flags.has("oneline-require"), false);
 });

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -30,7 +30,9 @@ export {
 }
 
 type SourceFlags =
-  | "fetch";
+  | "fetch"
+  | "oneline-require"
+  | "is-minified";
 
 interface SourceLocation {
   start: {
@@ -96,7 +98,6 @@ interface Report {
   flags: Set<SourceFlags>;
   idsLengthAvg: number;
   stringScore: number;
-  isOneLineRequire: boolean;
 }
 
 type ReportOnFile = {
@@ -104,7 +105,6 @@ type ReportOnFile = {
   warnings: Warning[];
   dependencies: Map<string, Dependency>;
   flags: Set<SourceFlags>;
-  isMinified: boolean;
 } | {
   ok: false,
   warnings: Warning[];


### PR DESCRIPTION
closes #325 
- Updated `SourceFlags` to include `oneline-require` and `is-minified`.
- Modified `AstAnalyser` to set the new flags based on analysis results.
- Adjusted tests to validate the new flag logic and removed deprecated `isOneLineRequire` references.