### PR TITLE
test(AstAnalyser): add tests for flags property and minified/oneline-require detection

### DIFF
--- a/test/AstAnalyser.spec.js
+++ b/test/AstAnalyser.spec.js
@@ -3,6 +3,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 // Import Internal Dependencies
 import { AstAnalyser, JsSourceParser } from "../index.js";
@@ -470,7 +472,7 @@ describe("AstAnalyser", (t) => {
     it("should add is-minified flag for minified files", () => {
       const minifiedContent = "var a=require(\"fs\"),b=require(\"http\");" +
         "a.readFile(\"test.txt\",function(c,d){b.createServer().listen(3000)});";
-      const tempMinFile = "temp-test.min.js";
+      const tempMinFile = path.join(os.tmpdir(), "temp-test.min.js");
 
       writeFileSync(tempMinFile, minifiedContent);
 
@@ -488,7 +490,7 @@ describe("AstAnalyser", (t) => {
 
     it("should add oneline-require flag for one-line exports", () => {
       const oneLineContent = "module.exports = require('foo');";
-      const tempOneLineFile = "temp-oneline.js";
+      const tempOneLineFile = path.join(os.tmpdir(), "temp-oneline.js");
 
       writeFileSync(tempOneLineFile, oneLineContent);
 

--- a/test/AstAnalyser.spec.js
+++ b/test/AstAnalyser.spec.js
@@ -460,16 +460,18 @@ describe("AstAnalyser", (t) => {
       assert.strictEqual(parsingError.kind, "parsing-error");
     });
 
-    it("should include flags property in response", () => {
+    it("should include flags property in response", (t) => {
+      t.plan(2);
       const result = getAnalyser().analyseFileSync(
         new URL("depName.js", FIXTURE_URL)
       );
 
-      assert.ok(result.ok);
-      assert.ok(result.flags instanceof Set);
+      t.assert.ok(result.ok);
+      t.assert.ok(result.flags instanceof Set);
     });
 
-    it("should add is-minified flag for minified files", () => {
+    it("should add is-minified flag for minified files", (t) => {
+      t.plan(3);
       const minifiedContent = "var a=require(\"fs\"),b=require(\"http\");" +
         "a.readFile(\"test.txt\",function(c,d){b.createServer().listen(3000)});";
       const tempMinFile = path.join(os.tmpdir(), "temp-test.min.js");
@@ -479,16 +481,17 @@ describe("AstAnalyser", (t) => {
       try {
         const result = getAnalyser().analyseFileSync(tempMinFile);
 
-        assert.ok(result.ok);
-        assert.ok(result.flags.has("is-minified"));
-        assert.strictEqual(result.flags.has("oneline-require"), false);
+        t.assert.ok(result.ok);
+        t.assert.ok(result.flags.has("is-minified"));
+        t.assert.strictEqual(result.flags.has("oneline-require"), false);
       }
       finally {
         unlinkSync(tempMinFile);
       }
     });
 
-    it("should add oneline-require flag for one-line exports", () => {
+    it("should add oneline-require flag for one-line exports", (t) => {
+      t.plan(4);
       const oneLineContent = "module.exports = require('foo');";
       const tempOneLineFile = path.join(os.tmpdir(), "temp-oneline.js");
 
@@ -497,10 +500,10 @@ describe("AstAnalyser", (t) => {
       try {
         const result = getAnalyser().analyseFileSync(tempOneLineFile);
 
-        assert.ok(result.ok);
-        assert.ok(result.flags.has("oneline-require"));
-        assert.strictEqual(result.flags.has("is-minified"), false);
-        assert.deepEqual([...result.dependencies.keys()], ["foo"]);
+        t.assert.ok(result.ok);
+        t.assert.ok(result.flags.has("oneline-require"));
+        t.assert.strictEqual(result.flags.has("is-minified"), false);
+        t.assert.deepEqual([...result.dependencies.keys()], ["foo"]);
       }
       finally {
         unlinkSync(tempOneLineFile);

--- a/test/AstAnalyser.spec.js
+++ b/test/AstAnalyser.spec.js
@@ -460,14 +460,13 @@ describe("AstAnalyser", (t) => {
       assert.strictEqual(parsingError.kind, "parsing-error");
     });
 
-    it("should include flags property in response", (t) => {
-      t.plan(2);
+    it("should include flags property in response", () => {
       const result = getAnalyser().analyseFileSync(
         new URL("depName.js", FIXTURE_URL)
       );
 
-      t.assert.ok(result.ok);
-      t.assert.ok(result.flags instanceof Set);
+      assert.ok(result.ok);
+      assert.ok(result.flags instanceof Set);
     });
 
     it("should add is-minified flag for minified files", (t) => {


### PR DESCRIPTION
### Tests

1. **`should include flags property in response`** - Ensures flags property exists and prevents regression where it was forgotten
2. **`should add is-minified flag for minified files`** - Tests minified content detection and flag setting  
3. **`should add oneline-require flag for one-line exports`** - Tests one-line require exports and flag mutual exclusion

#### Coverage
- Flags property existence
- "is-minified" flag functionality  
- "oneline-require" flag functionality
- Flag mutual exclusion logic