### PR TITLE
feat(isSerializeEnv): add named handler for direct process.env detection

### DIFF
--- a/.changeset/isserializeenv-named-handler.md
+++ b/.changeset/isserializeenv-named-handler.md
@@ -1,0 +1,19 @@
+---
+"@nodesecure/js-x-ray": minor
+---
+
+feat(isSerializeEnv): add named handler for direct process.env access detection
+
+Introduces a named handler pattern in the `isSerializeEnv` probe to detect direct `process.env` access when running in **aggressive** sensitivity mode.
+
+**Changes:**
+- Added `validateProcessEnv` validator to detect `process.env` MemberExpression nodes
+- Added `processEnvHandler` named handler that triggers only in aggressive mode
+- Converted probe export to use `NamedMainHandlers` pattern with `default` and `process.env` handlers
+- Existing `JSON.stringify(process.env)` detection remains unchanged (backward compatible)
+
+**Behavior:**
+- **Conservative mode (default)**: Only flags `process.env` when used with `JSON.stringify`
+- **Aggressive mode**: Additionally flags any direct `process.env` access
+
+Relates to #367

--- a/workspaces/js-x-ray/test/probes/isSerializeEnv.spec.ts
+++ b/workspaces/js-x-ray/test/probes/isSerializeEnv.spec.ts
@@ -13,8 +13,8 @@ test("should detect JSON.stringify(process.env)", () => {
 
   assert.strictEqual(sastAnalysis.warnings().length, 1);
   const warning = sastAnalysis.getWarning("serialize-environment");
-  assert.strictEqual(warning.kind, "serialize-environment");
-  assert.strictEqual(warning.value, "JSON.stringify(process.env)");
+  assert.strictEqual(warning?.kind, "serialize-environment");
+  assert.strictEqual(warning?.value, "JSON.stringify(process.env)");
 });
 
 test("should detect JSON.stringify(process['env'])", () => {
@@ -24,8 +24,8 @@ test("should detect JSON.stringify(process['env'])", () => {
 
   assert.strictEqual(sastAnalysis.warnings().length, 1);
   const warning = sastAnalysis.getWarning("serialize-environment");
-  assert.strictEqual(warning.kind, "serialize-environment");
-  assert.strictEqual(warning.value, "JSON.stringify(process.env)");
+  assert.strictEqual(warning?.kind, "serialize-environment");
+  assert.strictEqual(warning?.value, "JSON.stringify(process.env)");
 });
 
 test("should detect JSON.stringify(process[\"env\"])", () => {
@@ -35,8 +35,8 @@ test("should detect JSON.stringify(process[\"env\"])", () => {
 
   assert.strictEqual(sastAnalysis.warnings().length, 1);
   const warning = sastAnalysis.getWarning("serialize-environment");
-  assert.strictEqual(warning.kind, "serialize-environment");
-  assert.strictEqual(warning.value, "JSON.stringify(process.env)");
+  assert.strictEqual(warning?.kind, "serialize-environment");
+  assert.strictEqual(warning?.value, "JSON.stringify(process.env)");
 });
 
 test("should detect process.env reassignment", () => {
@@ -49,8 +49,8 @@ test("should detect process.env reassignment", () => {
 
   assert.strictEqual(sastAnalysis.warnings().length, 1);
   const warning = sastAnalysis.getWarning("serialize-environment");
-  assert.strictEqual(warning.kind, "serialize-environment");
-  assert.strictEqual(warning.value, "JSON.stringify(process.env)");
+  assert.strictEqual(warning?.kind, "serialize-environment");
+  assert.strictEqual(warning?.value, "JSON.stringify(process.env)");
 });
 
 test("should not detect process.env", () => {
@@ -76,8 +76,8 @@ test("should be able to detect reassigned JSON.stringify", () => {
 
   assert.strictEqual(sastAnalysis.warnings().length, 1);
   const warning = sastAnalysis.getWarning("serialize-environment");
-  assert.strictEqual(warning.kind, "serialize-environment");
-  assert.strictEqual(warning.value, "JSON.stringify(process.env)");
+  assert.strictEqual(warning?.kind, "serialize-environment");
+  assert.strictEqual(warning?.value, "JSON.stringify(process.env)");
 });
 
 test("should be able to detect serialization of process.env using a SpreadElement", () => {
@@ -90,8 +90,8 @@ test("should be able to detect serialization of process.env using a SpreadElemen
 
   assert.strictEqual(sastAnalysis.warnings().length, 1);
   const warning = sastAnalysis.getWarning("serialize-environment");
-  assert.strictEqual(warning.kind, "serialize-environment");
-  assert.strictEqual(warning.value, "JSON.stringify(process.env)");
+  assert.strictEqual(warning?.kind, "serialize-environment");
+  assert.strictEqual(warning?.value, "JSON.stringify(process.env)");
 });
 
 test("should not detect other JSON.stringify calls", () => {
@@ -102,10 +102,39 @@ test("should not detect other JSON.stringify calls", () => {
   assert.strictEqual(sastAnalysis.warnings().length, 0);
 });
 
-test("should not detect non-JSON.stringify calls", () => {
+test("should not detect direct process.env access in conservative mode (default)", () => {
   const str = "const env = process.env";
   const ast = parseScript(str);
   const sastAnalysis = getSastAnalysis(isSerializeEnv).execute(ast.body);
 
   assert.strictEqual(sastAnalysis.warnings().length, 0);
 });
+
+test("should detect direct process.env access in aggressive mode", () => {
+  const str = "const env = process.env";
+  const ast = parseScript(str);
+  const sastAnalysis = getSastAnalysis(isSerializeEnv, { sensitivity: "aggressive" }).execute(ast.body);
+
+  assert.strictEqual(sastAnalysis.warnings().length, 1);
+  const warning = sastAnalysis.getWarning("serialize-environment");
+  assert.strictEqual(warning?.kind, "serialize-environment");
+  assert.strictEqual(warning?.value, "process.env");
+});
+
+test("should detect process.env property access in aggressive mode", () => {
+  const str = "const home = process.env.HOME";
+  const ast = parseScript(str);
+  const sastAnalysis = getSastAnalysis(isSerializeEnv, { sensitivity: "aggressive" }).execute(ast.body);
+
+  // Should detect process.env as part of the MemberExpression chain
+  assert.strictEqual(sastAnalysis.warnings().length >= 1, true);
+});
+
+test("should NOT detect direct process.env access in explicit conservative mode", () => {
+  const str = "const env = process.env";
+  const ast = parseScript(str);
+  const sastAnalysis = getSastAnalysis(isSerializeEnv, { sensitivity: "conservative" }).execute(ast.body);
+
+  assert.strictEqual(sastAnalysis.warnings().length, 0);
+});
+


### PR DESCRIPTION
## Summary

This PR introduces a named handler in the `isSerializeEnv` probe to detect direct `process.env` access when running in aggressive sensitivity mode.

## Changes

- Added [validateProcessEnv](cci:1://file:///c:/Users/Hp/OneDrive/Desktop/2026%20plan/js-x-ray/workspaces/js-x-ray/src/probes/isSerializeEnv.ts:62:0-84:1) validator to detect `process.env` MemberExpression nodes
- Added [processEnvHandler](cci:1://file:///c:/Users/Hp/OneDrive/Desktop/2026%20plan/js-x-ray/workspaces/js-x-ray/src/probes/isSerializeEnv.ts:101:0-119:1) named handler that triggers only in aggressive mode
- Converted probe export to use [NamedMainHandlers](cci:2://file:///c:/Users/Hp/OneDrive/Desktop/2026%20plan/js-x-ray/workspaces/js-x-ray/src/ProbeRunner.ts:33:0-36:2) pattern with [default](cci:1://file:///c:/Users/Hp/OneDrive/Desktop/2026%20plan/js-x-ray/workspaces/js-x-ray/src/probes/isSerializeEnv.ts:86:0-99:1) and `process.env` handlers
- Added 4 new test cases for aggressive mode detection
- Fixed TypeScript strict mode warnings in test file

## Behavior

| Mode | `JSON.stringify(process.env)` | Direct `process.env` |
|------|------------------------------|---------------------|
| Conservative (default) | Warning | No warning |
| Aggressive | Warning | Warning |

## Backward Compatibility

Existing behavior in conservative mode is unchanged. The `JSON.stringify(process.env)` detection remains identical.

## Test Results

All 12 tests pass:
- 8 existing tests (backward compatibility)
- 4 new tests (aggressive mode detection)

Relates to #367