### PR TITLE
feat: add insecure-random probe

### DIFF
--- a/.changeset/detect-insecure-random.md
+++ b/.changeset/detect-insecure-random.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/js-x-ray": minor
+---
+
+Add insecure-random probe to detect Math.random() usage.

--- a/docs/insecure-random.md
+++ b/docs/insecure-random.md
@@ -1,0 +1,17 @@
+# Insecure random
+
+| Code | Severity | i18n | Experimental |
+| --- | --- | --- | :-: |
+| insecure-random | `Information` | `sast_warnings.insecure_random` | ❌ | 
+
+## Introduction
+
+Identify usage of the **insecure random** number generator `Math.random()`. `Math.random()` is not cryptographically secure and should not be used for security-sensitive operations like token generation, password salt, etc.
+
+It is recommended to use `crypto.randomBytes()` or `crypto.getRandomValues()` instead.
+
+## Example
+
+```js
+const token = Math.random().toString(36).substring(2);
+```

--- a/workspaces/js-x-ray/src/ProbeRunner.ts
+++ b/workspaces/js-x-ray/src/ProbeRunner.ts
@@ -23,6 +23,7 @@ import isUnsafeCallee from "./probes/isUnsafeCallee.ts";
 import isUnsafeCommand from "./probes/isUnsafeCommand.ts";
 import isWeakCrypto from "./probes/isWeakCrypto.ts";
 import isMonkeyPatch from "./probes/isMonkeyPatch.ts";
+import isRandom from "./probes/isRandom.ts";
 
 import type { TracedIdentifierReport } from "./VariableTracer.ts";
 import type { SourceFile } from "./SourceFile.ts";
@@ -107,7 +108,8 @@ export class ProbeRunner {
 
   static Optionals: Record<OptionalWarningName, Probe> = {
     "synchronous-io": isSyncIO,
-    "log-usage": logUsage
+    "log-usage": logUsage,
+    "insecure-random": isRandom
   };
 
   constructor(

--- a/workspaces/js-x-ray/src/i18n/english.js
+++ b/workspaces/js-x-ray/src/i18n/english.js
@@ -19,7 +19,8 @@ const sast_warnings = {
   data_exfiltration: "Detects serialization of sensitive system information (os.userInfo, os.networkInterfaces, os.cpus, dns.getServers) which could indicate unauthorized data collection for external transmission.",
   log_usage: "Usage of console logging methods (log, info, warn, error, debug) that may expose sensitive information in production environments.",
   sql_injection: "Template literals with interpolated expressions in SQL queries (SELECT, INSERT, UPDATE, DELETE) without proper parameterization, creating potential SQL injection vulnerabilities.",
-  monkey_patch: "Modification of native prototypes or global objects at runtime, which introduces security risks including flow hijacking, global side effects, and potential concealment of malicious activities."
+  monkey_patch: "Modification of native prototypes or global objects at runtime, which introduces security risks including flow hijacking, global side effects, and potential concealment of malicious activities.",
+  insecure_random: "Usage of insecure random number generation using Math.random(). Math.random() is not cryptographically secure and should not be used for security-sensitive operations."
 };
 
 export default {

--- a/workspaces/js-x-ray/src/i18n/french.js
+++ b/workspaces/js-x-ray/src/i18n/french.js
@@ -21,7 +21,8 @@ const sast_warnings = {
   data_exfiltration: "Détecte la sérialisation d'informations système sensibles (os.userInfo, os.networkInterfaces, os.cpus, dns.getServers) qui pourrait indiquer une collecte de données non autorisée pour transmission externe.",
   log_usage: "Utilisation de méthodes de l'API console (log, info, warn, error, debug) qui peuvent exposer des informations sensibles en environnement de production.",
   sql_injection: "Littéraux de gabarit avec expressions interpolées dans les requêtes SQL (SELECT, INSERT, UPDATE, DELETE) sans paramétrisation appropriée, créant des vulnérabilités potentielles d'injection SQL.",
-  monkey_patch: "Modification des prototypes natifs ou objets globaux à l'exécution, ce qui introduit des risques de sécurité incluant le détournement de flux, des effets secondaires globaux et la dissimulation potentielle d'activités malveillantes."
+  monkey_patch: "Modification des prototypes natifs ou objets globaux à l'exécution, ce qui introduit des risques de sécurité incluant le détournement de flux, des effets secondaires globaux et la dissimulation potentielle d'activités malveillantes.",
+  insecure_random: "Utilisation d'une génération de nombres aléatoires non sécurisée à l'aide de Math.random(). Math.random() n'est pas cryptographiquement sûr et ne doit pas être utilisé pour des opérations sensibles en matière de sécurité."
 };
 
 export default {

--- a/workspaces/js-x-ray/src/probes/isRandom.ts
+++ b/workspaces/js-x-ray/src/probes/isRandom.ts
@@ -1,0 +1,47 @@
+// Import Third-party Dependencies
+import type { ESTree } from "meriyah";
+
+// Import Internal Dependencies
+import type { ProbeContext } from "../ProbeRunner.ts";
+import { generateWarning } from "../warnings.ts";
+import { CALL_EXPRESSION_DATA } from "../contants.ts";
+
+function validateNode(
+  _node: ESTree.Node,
+  ctx: ProbeContext
+): [boolean, any?] {
+  return [
+    ctx.context![CALL_EXPRESSION_DATA]?.name === "Math.random"
+  ];
+}
+
+function initialize(
+  ctx: ProbeContext
+) {
+  const { tracer } = ctx.sourceFile;
+
+  tracer.trace("Math.random", {
+    followConsecutiveAssignment: true
+  });
+}
+
+function main(
+  node: ESTree.MemberExpression,
+  ctx: ProbeContext
+) {
+  const { sourceFile } = ctx;
+
+  sourceFile.warnings.push(generateWarning("insecure-random", {
+    value: null,
+    location: node.loc
+  }));
+}
+
+export default {
+  name: "isRandom",
+  validateNode,
+  main,
+  initialize,
+  breakOnMatch: false,
+  context: {}
+};

--- a/workspaces/js-x-ray/src/warnings.ts
+++ b/workspaces/js-x-ray/src/warnings.ts
@@ -11,7 +11,8 @@ import {
 
 export type OptionalWarningName =
   | "synchronous-io"
-  | "log-usage";
+  | "log-usage"
+  | "insecure-random";
 
 export type WarningName =
   | "parsing-error"
@@ -30,6 +31,7 @@ export type WarningName =
   | "data-exfiltration"
   | "sql-injection"
   | "monkey-patch"
+  | "insecure-random"
   | OptionalWarningName;
 
 export interface Warning<T = WarningName> {
@@ -132,6 +134,11 @@ export const warnings = Object.freeze({
   "monkey-patch": {
     i18n: "sast_warnings.monkey_patch",
     severity: "Warning",
+    experimental: false
+  },
+  "insecure-random": {
+    i18n: "sast_warnings.insecure_random",
+    severity: "Information",
     experimental: false
   }
 }) satisfies Record<WarningName, Pick<Warning, "experimental" | "i18n" | "severity">>;

--- a/workspaces/js-x-ray/test/probes/isRandom.spec.ts
+++ b/workspaces/js-x-ray/test/probes/isRandom.spec.ts
@@ -1,0 +1,42 @@
+
+// Import Node.js Dependencies
+import assert from "node:assert";
+import { test } from "node:test";
+
+// Import Internal Dependencies
+import { AstAnalyser } from "../../src/index.ts";
+
+test("it should report a warning for Math.random() usage when enabled", () => {
+  const code = `
+    const token = Math.random();
+  `;
+  const { warnings: outputWarnings } = new AstAnalyser({
+    optionalWarnings: ["insecure-random"]
+  }).analyse(code);
+
+  assert.strictEqual(outputWarnings.length, 1);
+  assert.strictEqual(outputWarnings[0].kind, "insecure-random");
+  assert.strictEqual(outputWarnings[0].value, null);
+});
+
+test("it should NOT report a warning for Math.random() if NOT enabled", () => {
+  const code = `
+    const token = Math.random();
+  `;
+  const { warnings: outputWarnings } = new AstAnalyser().analyse(code);
+
+  assert.strictEqual(outputWarnings.length, 0);
+});
+
+test("it should report a warning for Math.random() usage when reassigned", () => {
+  const code = `
+    const m = Math;
+    const token = m.random();
+  `;
+  const { warnings: outputWarnings } = new AstAnalyser({
+    optionalWarnings: ["insecure-random"]
+  }).analyse(code);
+
+  assert.strictEqual(outputWarnings.length, 1);
+  assert.strictEqual(outputWarnings[0].kind, "insecure-random");
+});


### PR DESCRIPTION
Adds an optional `insecure-random` probe to detect `Math.random()` usage.

The warning is informational and disabled by default.  
Includes tests for enabled/disabled cases.

Closes #506
