### PR TITLE
Feat/unsafe prehash

### DIFF
--- a/.changeset/bees-truly-shine.md
+++ b/.changeset/bees-truly-shine.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/js-x-ray": minor
+---
+
+feat(js-x-ray): add unsafe-prehash warning

--- a/docs/unsafe-prehash.md
+++ b/docs/unsafe-prehash.md
@@ -1,0 +1,99 @@
+# Unsafe prehash
+
+| Code | Severity | i18n | Experimental |
+| --- | --- | --- | :-: |
+| unsafe-prehash | `Warning` | `sast_warnings.unsafe_prehash` | :white_check_mark: |
+
+## Introduction
+
+Detect **unsafe password pre-hashing** before passing the result to [`bcryptjs`](https://www.npmjs.com/package/bcryptjs)'s `bcrypt.hash()` / `bcrypt.hashSync()`.
+
+Only `bcryptjs` is covered, not the `bcrypt` package. It gets roughly 2x `bcrypt`'s weekly npm downloads. Extending this probe to also cover `bcrypt` is a separate work.
+
+Pre-hashing a password by passing the raw digest `Buffer` directly can be dangerous: bcrypt treats its input as a null-terminated string, so a digest containing a `0x00` byte gets silently truncated at that byte, increasing the chance of hash collisions.
+
+This probe flags `bcrypt.hash()` / `bcrypt.hashSync()` calls (from `bcryptjs`) whose first argument is a `digest(encoding)` or `.digest().toString(encoding)` call that does not use a null-byte-free encoding (base64, base64url or hex).
+
+The probe also follows the common pattern of computing the digest first and passing it to bcrypt by reference.
+
+## How detection works
+
+`bcryptjs` is tracked through the codebase's shared `VariableTracer`, so all the common import forms are recognized:
+
+```js
+import bcrypt from "bcryptjs";        
+import * as bcrypt from "bcryptjs";   
+import { hash } from "bcryptjs";      
+// except this one: not recognized
+import { hash as bcryptHash } from "bcryptjs"; 
+```
+
+
+## Example
+
+```js
+import bcrypt from "bcryptjs";
+import crypto from "crypto";
+
+// unsafe: raw digest Buffer may contain a null byte
+bcrypt.hash(crypto.createHash("sha256").update(password).digest(), salt, callback);
+
+// unsafe: same issue, written as digest().toString(...)
+bcrypt.hash(crypto.createHash("sha256").update(password).digest().toString("binary"), salt, callback);
+
+// unsafe: same issue, with the digest stored in a variable first
+const prehashed = crypto.createHash("sha256").update(password).digest();
+bcrypt.hash(prehashed, salt, callback);
+
+// safe: base64 output never contains a null byte
+bcrypt.hash(crypto.createHash("sha256").update(password).digest("base64"), salt, callback);
+
+// safe: digest() already returned a safely-encoded hex string
+bcrypt.hash(crypto.createHash("sha256").update(password).digest("hex").toString("binary"), salt, callback);
+```
+
+## Limitations
+
+This probe is purely name-based and has no lexical scope resolution. Several consequences:
+
+- **The `bcrypt` package is not detected at all.**
+
+- **Renamed named imports aren't recognized.** This is a separate, `VariableTracer` limitation.
+
+  ```js
+  // not detected: aliased via "as", the local binding "bcryptHash" isn't tracked
+  import { hash as bcryptHash } from "bcryptjs";
+  bcryptHash(crypto.createHash("sha256").update(password).digest(), salt, callback);
+  ```
+
+- **Variable indirection only works one level deep, in source order.** The variable must be declared with `const`/`let`/`var` and an initializer earlier in the same file. 
+Reassignment, destructuring, function parameters, or a digest returned from a helper function are not tracked:
+
+  ```js
+  // not detected: the digest only reaches bcrypt through a function parameter
+  function hashPassword(prehashed) {
+    bcrypt.hash(prehashed, salt, callback);
+  }
+  hashPassword(crypto.createHash("sha256").update(password).digest());
+  ```
+
+- **Matching is by identifier name only, not by binding/scope, with two safeguards.** A name is excluded from matching if it's ever used as a function/arrow parameter anywhere in the file, *or* if it's declared by more than one `VariableDeclarator` anywhere in the file (a sign that two unrelated bindings happen to share a name). Together these cover the common collision shapes:
+
+  ```js
+  function foo() {
+    const prehashed = crypto.createHash("sha256").update(password).digest(); // unsafe, name "prehashed" is remembered
+  }
+
+  function bar(prehashed) { // excluded: "prehashed" is used as a parameter name elsewhere
+    bcrypt.hash(prehashed, salt, callback); // not flagged
+  }
+
+  function baz() {
+    const prehashed = someUnrelatedSafeValue(); // excluded: "prehashed" is declared more than once in the file
+    bcrypt.hash(prehashed, salt, callback); // not flagged
+  }
+  ```
+
+## References
+
+- [OWASP Password Storage Cheat Sheet — Pre-Hashing Passwords with bcrypt](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pre-hashing-passwords-with-bcrypt)

--- a/workspaces/js-x-ray/README.md
+++ b/workspaces/js-x-ray/README.md
@@ -124,7 +124,8 @@ Alternatively, you can use `EntryFilesAnalyser` directly for multi-file analysis
 type OptionalWarningName =
   | "synchronous-io"
   | "log-usage"
-  | "weak-scrypt";
+  | "weak-scrypt"
+  | "unsafe-prehash";
 
 type WarningName =
   | "parsing-error"
@@ -187,6 +188,7 @@ The following warnings are optional:
 - `synchronous-io` - Detects synchronous I/O operations that could impact performance
 - `log-usage` - Tracks usage of logging functions (console.log, logger.info, etc.)
 - `weak-scrypt` - Detects weak scrypt parameters (low cost, short or hardcoded salt)
+- `unsafe-prehash` - Detects password pre-hashing fed into bcrypt without a safe (base64/hex) digest encoding
 
 ### Internationalization (i18n)
 
@@ -234,6 +236,7 @@ Click on the warning **name** for detailed documentation and examples.
 | [monkey-patch](https://github.com/NodeSecure/js-x-ray/blob/master/docs/monkey-patch.md) | No | Modification of built-in JavaScript prototype properties |
 | [prototype-pollution](https://github.com/NodeSecure/js-x-ray/blob/master/docs/prototype-pollution.md) | No | Detected use of `__proto__` to pollute object prototypes |
 | [weak-scrypt](https://github.com/NodeSecure/js-x-ray/blob/master/docs/weak-scrypt.md) ⚠️ | **Yes** | Usage of weak scrypt parameters (low cost, short or hardcoded salt) |
+| [unsafe-prehash](https://github.com/NodeSecure/js-x-ray/blob/master/docs/unsafe-prehash.md) ⚠️ | **Yes** | Password pre-hashed and fed into bcrypt without a safe digest encoding |
 | [unsafe-vm-context](https://github.com/NodeSecure/js-x-ray/blob/master/docs/unsafe-vm-context.md) ⚠️ | No | Usage of dangerous vm.runInNewContext and (vm.Script(code,options)).runInContext |
 
 #### Information Severity

--- a/workspaces/js-x-ray/src/ProbeRunner.ts
+++ b/workspaces/js-x-ray/src/ProbeRunner.ts
@@ -27,6 +27,7 @@ import isMonkeyPatch from "./probes/isMonkeyPatch.ts";
 import isRandom from "./probes/isRandom.ts";
 import isPrototypePollution from "./probes/isPrototypePollution.ts";
 import isWeakScrypt from "./probes/isWeakScrypt.ts";
+import isUnsafePrehash from "./probes/isUnsafePrehash.ts";
 
 import type { TracedIdentifierReport } from "./VariableTracer.ts";
 import type { SourceFile } from "./SourceFile.ts";
@@ -128,7 +129,8 @@ export class ProbeRunner {
     "synchronous-io": isSyncIO,
     "log-usage": logUsage,
     "insecure-random": isRandom,
-    "weak-scrypt": isWeakScrypt
+    "weak-scrypt": isWeakScrypt,
+    "unsafe-prehash": isUnsafePrehash
   };
 
   constructor(

--- a/workspaces/js-x-ray/src/VariableTracer.ts
+++ b/workspaces/js-x-ray/src/VariableTracer.ts
@@ -399,6 +399,14 @@ export class VariableTracer extends EventEmitter {
       return;
     }
 
+    // import boo from "crypto";
+    if (node.specifiers[0].type === "ImportDefaultSpecifier") {
+      const importDefaultNode = node.specifiers[0];
+      this.#declareNewAssignment(moduleName, importDefaultNode.local);
+
+      return;
+    }
+
     // import { createHash } from "crypto";
     const importSpecifiers = node.specifiers
       .filter((specifierNode) => specifierNode.type === "ImportSpecifier");

--- a/workspaces/js-x-ray/src/estree/functions/getMemberCallExpression.ts
+++ b/workspaces/js-x-ray/src/estree/functions/getMemberCallExpression.ts
@@ -1,0 +1,24 @@
+// Import Third-party Dependencies
+import type { ESTree } from "meriyah";
+
+// Import Internal Dependencies
+import { isCallExpression } from "../types.ts";
+
+export type MemberCallExpression = ESTree.CallExpression & { callee: ESTree.MemberExpression; };
+
+export function getMemberCallExpression(
+  node: ESTree.Node | null | undefined,
+  methodName: string
+): MemberCallExpression | null {
+  if (
+    isCallExpression(node) &&
+    node.callee.type === "MemberExpression" &&
+    !node.callee.computed &&
+    node.callee.property.type === "Identifier" &&
+    node.callee.property.name === methodName
+  ) {
+    return node as MemberCallExpression;
+  }
+
+  return null;
+}

--- a/workspaces/js-x-ray/src/estree/index.ts
+++ b/workspaces/js-x-ray/src/estree/index.ts
@@ -1,4 +1,5 @@
 export * from "./functions/arrayExpression.ts";
+export * from "./functions/getMemberCallExpression.ts";
 export * from "./functions/concatBinaryExpression.ts";
 export * from "./functions/extractLogicalExpression.ts";
 export * from "./functions/getCallExpressionArguments.ts";

--- a/workspaces/js-x-ray/src/estree/types.ts
+++ b/workspaces/js-x-ray/src/estree/types.ts
@@ -46,6 +46,21 @@ export function isTemplateLiteral(
   );
 }
 
+export type FunctionNode =
+  | ESTree.FunctionDeclaration
+  | ESTree.FunctionExpression
+  | ESTree.ArrowFunctionExpression;
+
+export function isFunctionNode(
+  node: unknown
+): node is FunctionNode {
+  return isNode(node) && (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  );
+}
+
 export function isCallExpression(
   node: unknown
 ): node is ESTree.CallExpression {

--- a/workspaces/js-x-ray/src/probes/isUnsafePrehash.ts
+++ b/workspaces/js-x-ray/src/probes/isUnsafePrehash.ts
@@ -1,0 +1,250 @@
+// Import Third-party Dependencies
+import type { ESTree } from "meriyah";
+
+// Import Internal Dependencies
+import type { ProbeContext, ProbeMainContext } from "../ProbeRunner.ts";
+import { CALL_EXPRESSION_DATA } from "../contants.ts";
+import { isCallExpression, isLiteral } from "../estree/types.ts";
+import { getVariableDeclarationIdentifiers } from "../estree/index.ts";
+import { generateWarning } from "../warnings.ts";
+import {
+  VariableTracer,
+  type LiteralIdentifier,
+  type ReturnValueEventPayload
+} from "../VariableTracer.ts";
+
+const kModuleName = "bcryptjs";
+const kTracedFunctions = new Set(["bcryptjs.hash", "bcryptjs.hashSync"]);
+
+const kUnsafeDigestVariables = Symbol("unsafeDigestVariables");
+const kAmbiguousVariableNames = Symbol("ambiguousVariableNames");
+
+interface UnsafePrehashContext {
+  [kUnsafeDigestVariables]?: Set<string>;
+  [kAmbiguousVariableNames]?: Set<string>;
+}
+
+type UnsafePrehashContextSetKey =
+  | typeof kUnsafeDigestVariables
+  | typeof kAmbiguousVariableNames;
+
+function getContextSet(
+  ctx: ProbeContext<UnsafePrehashContext>,
+  key: UnsafePrehashContextSetKey
+): Set<string> {
+  return ctx.context![key]!;
+}
+
+/**
+ * Digest encodings that produce ASCII-only output, avoiding the null-byte truncation issue
+ */
+const kSafeDigestEncodings = new Set(["base64", "base64url", "hex"]);
+
+const kDigestChains = [
+  "crypto.createHash.update.digest",
+  "crypto.createHash.update.digest.toString",
+  "crypto.createHash.digest",
+  "crypto.createHash.digest.toString",
+  "crypto.createHmac.update.digest",
+  "crypto.createHmac.update.digest.toString",
+  "crypto.createHmac.digest",
+  "crypto.createHmac.digest.toString"
+] as const;
+
+/**
+ * Resolves both `x.digest(encoding)` and `x.digest().toString(encoding)`
+ */
+function resolveDigestEncodingArguments(
+  hashNode: ESTree.Node | null | undefined
+): ESTree.Node[] | null {
+  const digestCall = getMemberCallExpression(hashNode, "digest");
+  if (digestCall) {
+    return digestCall.arguments;
+  }
+
+  const toStringCall = getMemberCallExpression(hashNode, "toString");
+  if (toStringCall) {
+    const innerDigestCall = getMemberCallExpression(toStringCall.callee.object, "digest");
+    if (innerDigestCall) {
+      return innerDigestCall.arguments.length === 0
+        ? toStringCall.arguments
+        : innerDigestCall.arguments;
+    }
+  }
+
+  return null;
+}
+
+function getParamNames(
+  params: ESTree.Node[]
+): string[] {
+  const names: string[] = [];
+
+  for (const param of params) {
+    for (const { assignmentId } of getVariableDeclarationIdentifiers(param)) {
+      names.push(assignmentId.name);
+    }
+  }
+
+  return names;
+}
+
+function isSafeEncodingArg(
+  node: ESTree.Node | undefined,
+  literalIdentifiers: Map<string, LiteralIdentifier>
+): boolean {
+  if (isLiteral(node)) {
+    return kSafeDigestEncodings.has(node.value);
+  }
+
+  if (node?.type === "Identifier") {
+    const literal = literalIdentifiers.get(node.name);
+
+    return literal !== undefined && kSafeDigestEncodings.has(literal.value);
+  }
+
+  return false;
+}
+
+function hasUnsafeDigestEncoding(
+  hashNode: ESTree.Node | null | undefined,
+  literalIdentifiers: Map<string, LiteralIdentifier>
+): boolean {
+  const encodingArgs = resolveDigestEncodingArguments(hashNode);
+  if (encodingArgs === null) {
+    return false;
+  }
+
+  return !isSafeEncodingArg(encodingArgs.at(0), literalIdentifiers);
+}
+
+type NodeValidationResult =
+  [false] |
+  [true] |
+  [true, string[]];
+
+function validateNode(
+  node: ESTree.Node,
+  ctx: ProbeContext<UnsafePrehashContext>
+): NodeValidationResult {
+  const { tracer } = ctx.sourceFile;
+
+  if (!tracer.importedModules.has(kModuleName) || !tracer.importedModules.has("crypto")) {
+    return [false];
+  }
+
+  if (isFunctionNode(node)) {
+    const paramNames = getParamNames(node.params);
+    const unsafeVars = getContextSet(ctx, kUnsafeDigestVariables);
+
+    if (paramNames.some((name) => unsafeVars.has(name))) {
+      ctx.setEntryPoint("markAmbiguousParams");
+
+      return [true, paramNames];
+    }
+
+    return [false];
+  }
+
+  return [
+    kTracedFunctions.has(ctx.context![CALL_EXPRESSION_DATA]?.identifierOrMemberExpr)
+  ];
+}
+
+function initialize(ctx: ProbeContext<UnsafePrehashContext>) {
+  const { tracer } = ctx.sourceFile;
+
+  ctx.context![kUnsafeDigestVariables] = new Set<string>();
+  ctx.context![kAmbiguousVariableNames] = new Set<string>();
+
+  for (const identifierOrMemberExpr of kTracedFunctions) {
+    tracer.trace(identifierOrMemberExpr, {
+      followConsecutiveAssignment: true,
+      moduleName: kModuleName
+    });
+  }
+
+  for (const chain of kDigestChains) {
+    tracer.trace(chain, {
+      followReturnValueAssignement: true,
+      followConsecutiveAssignment: true,
+      moduleName: "crypto"
+    });
+  }
+
+  tracer.on(VariableTracer.ReturnValueEvent, (payload: ReturnValueEventPayload) => {
+    if (!(kDigestChains as readonly string[]).includes(payload.identifierOrMemberExpr)) {
+      return;
+    }
+
+    const encodingArg = payload.arguments.at(0);
+    if (!isSafeEncodingArg(encodingArg, tracer.literalIdentifiers)) {
+      ctx.context![kUnsafeDigestVariables]!.add(payload.id);
+    }
+  });
+}
+
+function markAmbiguousParams(
+  _node: ESTree.Node,
+  ctx: ProbeMainContext<UnsafePrehashContext>
+) {
+  const ambiguousVariableNames = getContextSet(ctx, kAmbiguousVariableNames);
+  for (const name of ctx.data as string[]) {
+    ambiguousVariableNames.add(name);
+  }
+}
+
+function bcryptHashCall(
+  bcryptNode: ESTree.CallExpression,
+  ctx: ProbeMainContext<UnsafePrehashContext>
+) {
+  const { sourceFile } = ctx;
+  const hashArgument = bcryptNode.arguments.at(0);
+
+  let isUnsafe: boolean;
+  if (hashArgument?.type === "Identifier") {
+    const isAmbiguous = getContextSet(ctx, kAmbiguousVariableNames).has(hashArgument.name);
+    const isDigestVariable = getContextSet(ctx, kUnsafeDigestVariables).has(hashArgument.name);
+
+    isUnsafe = !isAmbiguous && isDigestVariable;
+  }
+  else if (
+    hashArgument?.type === "CallExpression" &&
+    hashArgument.callee.type === "Identifier" &&
+    !getContextSet(ctx, kAmbiguousVariableNames).has(hashArgument.callee.name) &&
+    getContextSet(ctx, kUnsafeDigestVariables).has(hashArgument.callee.name)
+  ) {
+    const encodingArg = hashArgument.arguments.at(0);
+    isUnsafe = !isSafeEncodingArg(encodingArg, sourceFile.tracer.literalIdentifiers);
+  }
+  else {
+    isUnsafe = hasUnsafeDigestEncoding(hashArgument, sourceFile.tracer.literalIdentifiers);
+  }
+
+  if (isUnsafe) {
+    sourceFile.warnings.push(
+      generateWarning("unsafe-prehash", {
+        value: null,
+        location: bcryptNode.loc
+      })
+    );
+  }
+}
+
+export default {
+  name: "isUnsafePrehash",
+  nodeTypes: [
+    "CallExpression",
+    "FunctionDeclaration",
+    "FunctionExpression",
+    "ArrowFunctionExpression"
+  ],
+  validateNode,
+  main: {
+    default: bcryptHashCall,
+    markAmbiguousParams
+  },
+  initialize,
+  breakOnMatch: false,
+  context: {}
+};

--- a/workspaces/js-x-ray/src/probes/isUnsafePrehash.ts
+++ b/workspaces/js-x-ray/src/probes/isUnsafePrehash.ts
@@ -4,8 +4,8 @@ import type { ESTree } from "meriyah";
 // Import Internal Dependencies
 import type { ProbeContext, ProbeMainContext } from "../ProbeRunner.ts";
 import { CALL_EXPRESSION_DATA } from "../contants.ts";
-import { isCallExpression, isLiteral } from "../estree/types.ts";
-import { getVariableDeclarationIdentifiers } from "../estree/index.ts";
+import { isLiteral, isFunctionNode } from "../estree/types.ts";
+import { getVariableDeclarationIdentifiers, getMemberCallExpression } from "../estree/index.ts";
 import { generateWarning } from "../warnings.ts";
 import {
   VariableTracer,

--- a/workspaces/js-x-ray/src/warnings.ts
+++ b/workspaces/js-x-ray/src/warnings.ts
@@ -13,7 +13,8 @@ export type OptionalWarningName =
   | "synchronous-io"
   | "log-usage"
   | "insecure-random"
-  | "weak-scrypt";
+  | "weak-scrypt"
+  | "unsafe-prehash";
 
 export type WarningName =
   | "parsing-error"
@@ -151,6 +152,11 @@ export const warnings = Object.freeze({
   },
   "weak-scrypt": {
     i18n: "sast_warnings.weak_scrypt",
+    severity: "Warning",
+    experimental: true
+  },
+  "unsafe-prehash": {
+    i18n: "sast_warnings.unsafe_prehash",
     severity: "Warning",
     experimental: true
   },

--- a/workspaces/js-x-ray/test/VariableTracer/VariableTracer.spec.ts
+++ b/workspaces/js-x-ray/test/VariableTracer/VariableTracer.spec.ts
@@ -45,6 +45,58 @@ test("it should trace re-assignment from a module import using /promises", () =>
   });
 });
 
+test("it should trace a default import aliased to a different local name", () => {
+  const helpers = createTracer(false);
+  helpers.tracer.trace("crypto.createHash", {
+    followConsecutiveAssignment: true,
+    moduleName: "crypto"
+  });
+  helpers.walkOnCode(`
+    import c from "crypto";
+
+    const h = c.createHash("md5");
+  `);
+
+  const result = helpers.tracer.getDataFromIdentifier("c.createHash");
+
+  assert.deepEqual(result, {
+    assignmentMemory: [
+      {
+        type: "AliasBinding",
+        name: "c"
+      }
+    ],
+    identifierOrMemberExpr: "crypto.createHash",
+    name: "crypto.createHash"
+  });
+});
+
+test("it should trace a namespace import aliased to a different local name", () => {
+  const helpers = createTracer(false);
+  helpers.tracer.trace("crypto.createHash", {
+    followConsecutiveAssignment: true,
+    moduleName: "crypto"
+  });
+  helpers.walkOnCode(`
+    import * as c from "crypto";
+
+    const h = c.createHash("md5");
+  `);
+
+  const result = helpers.tracer.getDataFromIdentifier("c.createHash");
+
+  assert.deepEqual(result, {
+    assignmentMemory: [
+      {
+        type: "AliasBinding",
+        name: "c"
+      }
+    ],
+    identifierOrMemberExpr: "crypto.createHash",
+    name: "crypto.createHash"
+  });
+});
+
 test("it should be able to Trace a malicious code with Global, BinaryExpr, Assignments and Hexadecimal", () => {
   const helpers = createTracer(true);
   const assignments = helpers.getAssignmentArray();

--- a/workspaces/js-x-ray/test/estree/getMemberCallExpression.spec.ts
+++ b/workspaces/js-x-ray/test/estree/getMemberCallExpression.spec.ts
@@ -1,0 +1,85 @@
+// Import Node.js Dependencies
+import assert from "node:assert";
+import { describe, test } from "node:test";
+
+// Import Internal Dependencies
+import { getMemberCallExpression } from "../../src/estree/index.ts";
+import {
+  parseScript,
+  getExpressionFromStatementIf
+} from "../helpers.ts";
+
+describe("estree.getMemberCallExpression", () => {
+  test("return null for null or undefined", () => {
+    assert.strictEqual(getMemberCallExpression(null, "digest"), null);
+    assert.strictEqual(getMemberCallExpression(undefined, "digest"), null);
+  });
+
+  test("return null when node is not a CallExpression", () => {
+    const [astNode] = parseScript("foo.bar").body;
+
+    assert.strictEqual(
+      getMemberCallExpression(getExpressionFromStatementIf(astNode), "bar"),
+      null
+    );
+  });
+
+  test("return null when callee is a plain Identifier, not a MemberExpression", () => {
+    const [astNode] = parseScript("digest()").body;
+
+    assert.strictEqual(
+      getMemberCallExpression(getExpressionFromStatementIf(astNode), "digest"),
+      null
+    );
+  });
+
+  test("return null when method name does not match", () => {
+    const [astNode] = parseScript("hash.update('data')").body;
+
+    assert.strictEqual(
+      getMemberCallExpression(getExpressionFromStatementIf(astNode), "digest"),
+      null
+    );
+  });
+
+  test("return null when property is computed", () => {
+    const [astNode] = parseScript("hash['digest']()").body;
+
+    assert.strictEqual(
+      getMemberCallExpression(getExpressionFromStatementIf(astNode), "digest"),
+      null
+    );
+  });
+
+  test("return the node when method name matches", () => {
+    const [astNode] = parseScript("hash.digest('hex')").body;
+    const node = getExpressionFromStatementIf(astNode);
+
+    const result = getMemberCallExpression(node, "digest");
+
+    assert.ok(result !== null);
+    assert.strictEqual(result.type, "CallExpression");
+    assert.strictEqual(result.callee.type, "MemberExpression");
+    assert.strictEqual((result.callee.property as any).name, "digest");
+  });
+
+  test("returned node carries the original arguments", () => {
+    const [astNode] = parseScript("hash.digest('hex')").body;
+    const node = getExpressionFromStatementIf(astNode);
+
+    const result = getMemberCallExpression(node, "digest")!;
+
+    assert.strictEqual(result.arguments.length, 1);
+    assert.strictEqual((result.arguments[0] as any).value, "hex");
+  });
+
+  test("return the node for chained member call", () => {
+    const [astNode] = parseScript("crypto.createHash('sha256').digest('hex')").body;
+    const node = getExpressionFromStatementIf(astNode);
+
+    const result = getMemberCallExpression(node, "digest");
+
+    assert.ok(result !== null);
+    assert.strictEqual((result.callee.property as any).name, "digest");
+  });
+});

--- a/workspaces/js-x-ray/test/probes/isUnsafePrehash.spec.ts
+++ b/workspaces/js-x-ray/test/probes/isUnsafePrehash.spec.ts
@@ -1,0 +1,467 @@
+// Import Node.js Dependencies
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+// Import Internal Dependencies
+import { AstAnalyser } from "../../src/index.ts";
+
+describe("isUnsafePrehash probe", () => {
+  describe("unsafe-prehash", () => {
+    it("should warn when a raw digest() (no encoding) is passed to bcryptjs.hash", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest(), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should warn when a raw digest() (no encoding) is passed to bcryptjs.hashSync", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        const hash = bcrypt.hashSync(crypto.createHash('sha256').update(password).digest(), salt);
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should warn when digest() uses an unsafe encoding (binary/latin1)", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest('binary'), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should warn for createHmac digest chains too", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHmac('sha384', pepper).update(password).digest(), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should warn when digest().toString() (no encoding) is used", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest().toString(), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should warn when digest().toString('binary') is used", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest().toString('binary'), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should warn when digest('binary').toString('hex') is used (outer toString is a no-op)", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest('binary').toString('hex'), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should warn when bcryptjs is imported as a namespace", () => {
+      const code = `
+        import * as bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest(), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should warn when bcryptjs.hash is imported as a named import", () => {
+      const code = `
+        import { hash } from 'bcryptjs';
+        import crypto from 'crypto';
+        hash(crypto.createHash('sha256').update(password).digest(), salt, (err, h) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+    it("should warn when digest is reassigned, then called as hash argument", () => {
+      const code = `
+        import * as bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        const digest = crypto.createHash('sha256').update(password).digest;
+        bcrypt.hash(digest(), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+  });
+
+  describe("variable indirection", () => {
+    it("should warn when an unsafely pre-hashed variable is passed to bcryptjs.hash", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        const prehashed = crypto.createHash('sha256').update(password).digest();
+        bcrypt.hash(prehashed, salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should warn when an unsafely pre-hashed variable (via toString) is passed to bcryptjs.hashSync", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        const prehashed = crypto.createHash('sha256').update(password).digest().toString('binary');
+        const hash = bcrypt.hashSync(prehashed, salt);
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+
+    it("should not warn when a safely pre-hashed variable is passed to bcryptjs.hash", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        const prehashed = crypto.createHash('sha256').update(password).digest('base64');
+        bcrypt.hash(prehashed, salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when the bcryptjs argument variable is unrelated to any digest", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        const plainValue = getUserInput();
+        bcrypt.hash(plainValue, salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when an unrelated function parameter shares its name with an unsafe pre-hashed variable", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+
+        function bar(prehashed) {
+          bcrypt.hash(prehashed, salt, (err, hash) => {});
+        }
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when an unrelated arrow function parameter shares its name with an unsafe pre-hashed variable", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+
+        const bar = (prehashed) => {
+          bcrypt.hash(prehashed, salt, (err, hash) => {});
+        };
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when an unrelated destructured parameter shares its name with an unsafe pre-hashed variable", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+
+        function foo() {
+          const prehashed = crypto.createHash('sha256').update(password).digest();
+        }
+
+        function bar({ prehashed }) {
+          bcrypt.hash(prehashed, salt, (err, hash) => {});
+        }
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when an unrelated local variable shares its name with an unsafe pre-hashed variable", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+
+        function bar() {
+          const prehashed = someUnrelatedSafeValue();
+          bcrypt.hash(prehashed, salt, (err, hash) => {});
+        }
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should still warn for the unsafe declarator itself when its name later collides with an unrelated variable", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+
+        function foo() {
+          const prehashed = crypto.createHash('sha256').update(password).digest();
+          bcrypt.hash(prehashed, salt, (err, hash) => {});
+        }
+
+        function bar() {
+          const prehashed = someUnrelatedSafeValue();
+        }
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "unsafe-prehash");
+    });
+  });
+
+  describe("no warning (proper usage)", () => {
+    it("should not warn when digest() uses base64 encoding", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest('base64'), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when digest() uses hex encoding", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest('hex'), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when the encoding is stored in an identifier pointing to a safe literal", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        const encoding = 'hex';
+        const prehashed = crypto.createHash('sha256').update(password).digest(encoding);
+        bcrypt.hash(prehashed, salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when digest().toString('hex') is used", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest().toString('hex'), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when digest('hex').toString('binary') is used", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest('hex').toString('binary'), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn for a plain bcryptjs.hash call without pre-hashing", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(password, salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when crypto module is not imported", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        const crypto = { createHash() { return { update() { return this; }, digest() {} }; } };
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest(), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when bcryptjs module is not imported", () => {
+      const code = `
+        import crypto from 'crypto';
+        const bcrypt = { hash() {} };
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest(), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+
+  describe("known limitations", () => {
+    it("should not warn for the real bcrypt package (only bcryptjs is supported)", () => {
+      const code = `
+        import bcrypt from 'bcrypt';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest(), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn for a renamed bcryptjs named import (known VariableTracer limitation)", () => {
+      const code = `
+        import { hash as bcryptHash } from 'bcryptjs';
+        import crypto from 'crypto';
+        bcryptHash(crypto.createHash('sha256').update(password).digest(), salt, (err, h) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when an unsafely pre-hashed digest reaches bcrypt through a function parameter", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+
+        function hashPassword(prehashed) {
+          bcrypt.hash(prehashed, salt, callback);
+        }
+        hashPassword(crypto.createHash('sha256').update(password).digest());
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["unsafe-prehash"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+
+  describe("optional warning behavior", () => {
+    it("should NOT report warnings when unsafe-prehash is not enabled", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest(), salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser().analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
Adds an optional unsafe-prehash probe to detect insecure usage of null byte enconding prehash, commonly used later on with bcrypt

Partially complete https://github.com/NodeSecure/js-x-ray/issues/506 for bcrypt (prehash is a subset)