### PR TITLE
fix(js-x-ray/shady-link): avoid false positive when IPv6 hostname is equal to ::

### DIFF
--- a/.changeset/wild-trains-smell.md
+++ b/.changeset/wild-trains-smell.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/js-x-ray": patch
+---
+
+Avoid false positive when IPv6 hostname is equal to '::'

--- a/workspaces/js-x-ray/src/ShadyLink.ts
+++ b/workspaces/js-x-ray/src/ShadyLink.ts
@@ -100,7 +100,8 @@ export class ShadyLink {
       ? hostname.slice(1, -1)
       : hostname;
 
-    if (this.isValidIPAddress(cleanHostname)) {
+    // Keep :: excluded from generic IP validation while still classifying it as a local URL host.
+    if (cleanHostname === "::" || this.isValidIPAddress(cleanHostname)) {
       const result = this.isIpAddressSafe(cleanHostname, {
         collectableSetRegistry,
         file,
@@ -127,6 +128,9 @@ export class ShadyLink {
 
   static isValidIPAddress(input: string): boolean {
     if (input.length > 45 || /\s/.test(input)) {
+      return false;
+    }
+    if (input === "::") {
       return false;
     }
 

--- a/workspaces/js-x-ray/test/ShadyLink.spec.ts
+++ b/workspaces/js-x-ray/test/ShadyLink.spec.ts
@@ -90,6 +90,12 @@ describe("ShadyLink.isURLSafe()", () => {
         }), { safe: false, isLocalAddress: true });
       });
 
+      it("should return false for IPv6 unspecified address", () => {
+        assert.deepEqual(ShadyLink.isURLSafe("https://[::]/path", {
+          collectableSetRegistry
+        }), { safe: false, isLocalAddress: true });
+      });
+
       it("should return false for IPv4-mapped IPv6 private address", () => {
         assert.deepEqual(ShadyLink.isURLSafe("https://[::ffff:127.0.0.1]/path", {
           collectableSetRegistry
@@ -429,6 +435,7 @@ describe("ShadyLink.isValidIpAddress()", () => {
 
   it("should not be a valid address", () => {
     assert.ok(!ShadyLink.isValidIPAddress("127.0.0.1.1"));
+    assert.ok(!ShadyLink.isValidIPAddress("::"));
   });
 
   // https://github.com/NodeSecure/js-x-ray/issues/474


### PR DESCRIPTION
close #595 