### PR TITLE
Feat/weak bcrypt

### DIFF
--- a/.changeset/floppy-apples-turn.md
+++ b/.changeset/floppy-apples-turn.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/js-x-ray": minor
+---
+
+feat(probe): Detect weak bcrypt usage

--- a/docs/weak-bcrypt.md
+++ b/docs/weak-bcrypt.md
@@ -1,0 +1,59 @@
+# Weak bcrypt
+
+| Code | Severity | i18n | Experimental |
+| --- | --- | --- | :-: |
+| weak-bcrypt | `Warning` | `sast_warnings.weak_bcrypt` | :white_check_mark: |
+
+## Introduction
+
+Detect usage of **weak bcrypt** parameters with the `bcryptjs` npm package. This probe checks for:
+
+- **low-cost**: the work factor (rounds) passed to `hash`, `hashSync`, `genSalt`, or `genSaltSync` is below the [OWASP minimum recommendation](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#bcrypt) of **10**.
+- **hardcoded-salt**: a salt is supplied as a hardcoded string literal instead of being randomly generated.
+
+> **NOTE**
+> This warning is **optional** and must be explicitly enabled via the `optionalWarnings` option.
+
+> **NOTE**
+> Only the `bcryptjs` package is supported. The older `bcrypt` (native binding) package is not tracked.
+
+## Example
+
+```js
+import bcrypt from "bcryptjs";
+
+// low-cost: rounds (8) is below the OWASP minimum of 10
+bcrypt.hash(password, 8, (err, hash) => {});
+
+// low-cost: rounds (4) is too low
+const hash = bcrypt.hashSync(password, 4);
+
+// low-cost: generating a salt with fewer than 10 rounds
+bcrypt.genSalt(8, (err, salt) => {});
+
+// hardcoded-salt: salt should be randomly generated, not a string literal
+bcrypt.hash(password, "$2b$10$N9qo8uLOickgx2ZMRZoMye", (err, hash) => {});
+```
+
+## Usage
+
+```js
+import { AstAnalyser } from "@nodesecure/js-x-ray";
+
+const { warnings } = new AstAnalyser({
+  optionalWarnings: ["weak-bcrypt"]
+}).analyse(source);
+```
+
+## Safe alternatives
+
+```js
+import bcrypt from "bcryptjs";
+
+// Use at least 10 rounds
+const hash = await bcrypt.hash(password, 12);
+
+// Or generate a random salt with sufficient rounds
+const salt = await bcrypt.genSalt(12);
+const hash = await bcrypt.hash(password, salt);
+```

--- a/workspaces/js-x-ray/README.md
+++ b/workspaces/js-x-ray/README.md
@@ -27,6 +27,7 @@ JS-X-Ray parses JS or TS code into an **Abstract Syntax Tree (AST)** with no ext
 - Flag weak cryptographic usage
   - Deprecated algorithms (MD5, SHA1, MD4, MD2, RIPEMD160)
   - Weak scrypt parameters (insufficient cost, short or hardcoded salt)
+  - Weak bcrypt parameters (low work factor, hardcoded salt)
 - Detect code quality issues
   - Monkey-patching of built-in prototypes
   - Encoded literals (hex, Unicode, base64)
@@ -125,7 +126,8 @@ type OptionalWarningName =
   | "synchronous-io"
   | "log-usage"
   | "weak-scrypt"
-  | "unsafe-prehash";
+  | "unsafe-prehash"
+  | "weak-bcrypt";
 
 type WarningName =
   | "parsing-error"
@@ -189,6 +191,7 @@ The following warnings are optional:
 - `log-usage` - Tracks usage of logging functions (console.log, logger.info, etc.)
 - `weak-scrypt` - Detects weak scrypt parameters (low cost, short or hardcoded salt)
 - `unsafe-prehash` - Detects password pre-hashing fed into bcrypt without a safe (base64/hex) digest encoding
+- `weak-bcrypt` - Detects weak bcrypt parameters (low work factor, hardcoded salt)
 
 ### Internationalization (i18n)
 
@@ -237,6 +240,7 @@ Click on the warning **name** for detailed documentation and examples.
 | [prototype-pollution](https://github.com/NodeSecure/js-x-ray/blob/master/docs/prototype-pollution.md) | No | Detected use of `__proto__` to pollute object prototypes |
 | [weak-scrypt](https://github.com/NodeSecure/js-x-ray/blob/master/docs/weak-scrypt.md) ⚠️ | **Yes** | Usage of weak scrypt parameters (low cost, short or hardcoded salt) |
 | [unsafe-prehash](https://github.com/NodeSecure/js-x-ray/blob/master/docs/unsafe-prehash.md) ⚠️ | **Yes** | Password pre-hashed and fed into bcrypt without a safe digest encoding |
+| [weak-bcrypt](https://github.com/NodeSecure/js-x-ray/blob/master/docs/weak-bcrypt.md) ⚠️ | **Yes** | Usage of weak bcrypt parameters (low work factor or hardcoded salt) |
 | [unsafe-vm-context](https://github.com/NodeSecure/js-x-ray/blob/master/docs/unsafe-vm-context.md) ⚠️ | No | Usage of dangerous vm.runInNewContext and (vm.Script(code,options)).runInContext |
 
 #### Information Severity

--- a/workspaces/js-x-ray/src/ProbeRunner.ts
+++ b/workspaces/js-x-ray/src/ProbeRunner.ts
@@ -28,6 +28,7 @@ import isRandom from "./probes/isRandom.ts";
 import isPrototypePollution from "./probes/isPrototypePollution.ts";
 import isWeakScrypt from "./probes/isWeakScrypt.ts";
 import isUnsafePrehash from "./probes/isUnsafePrehash.ts";
+import isWeakBcrypt from "./probes/isWeakBcrypt.ts";
 
 import type { TracedIdentifierReport } from "./VariableTracer.ts";
 import type { SourceFile } from "./SourceFile.ts";
@@ -130,7 +131,8 @@ export class ProbeRunner {
     "log-usage": logUsage,
     "insecure-random": isRandom,
     "weak-scrypt": isWeakScrypt,
-    "unsafe-prehash": isUnsafePrehash
+    "unsafe-prehash": isUnsafePrehash,
+    "weak-bcrypt": isWeakBcrypt
   };
 
   constructor(

--- a/workspaces/js-x-ray/src/estree/types.ts
+++ b/workspaces/js-x-ray/src/estree/types.ts
@@ -28,6 +28,14 @@ export function isLiteral(
     typeof node.value === "string";
 }
 
+export function isNumericLiteral(
+  node: unknown
+): node is Literal<number> {
+  return isNode(node) &&
+    node.type === "Literal" &&
+    typeof (node as ESTree.Literal).value === "number";
+}
+
 export function isTemplateLiteral(
   node: unknown
 ): node is ESTree.TemplateLiteral {

--- a/workspaces/js-x-ray/src/probes/isWeakBcrypt.ts
+++ b/workspaces/js-x-ray/src/probes/isWeakBcrypt.ts
@@ -1,0 +1,110 @@
+// Import Third-party Dependencies
+import type { ESTree } from "meriyah";
+
+// Import Internal Dependencies
+import type { ProbeContext, ProbeMainContext } from "../ProbeRunner.ts";
+import { CALL_EXPRESSION_DATA } from "../contants.ts";
+import { isLiteral } from "../estree/types.ts";
+import { generateWarning } from "../warnings.ts";
+
+const kMinRounds = 10;
+
+const kModuleName = "bcrypt";
+
+// Maps a traced bcrypt function name to the argument index
+const kTracedFunctionsWithArgIndex = new Map([
+  ["hash", 1],
+  ["hashSync", 1],
+  ["genSalt", 0],
+  ["genSaltSync", 0]
+]);
+
+function isNumericLiteral(
+  node: unknown
+): node is ESTree.Literal & { value: number; } {
+  return Boolean(node) &&
+    (node as ESTree.Node).type === "Literal" &&
+    typeof (node as ESTree.Literal).value === "number";
+}
+
+function validateNode(
+  _node: ESTree.Node,
+  ctx: ProbeContext
+): [boolean, any?] {
+  const { tracer } = ctx.sourceFile;
+
+  if (!tracer.importedModules.has(kModuleName)) {
+    return [false];
+  }
+
+  const identifierOrMemberExpr = ctx.context![CALL_EXPRESSION_DATA]?.identifierOrMemberExpr;
+  if (!identifierOrMemberExpr) {
+    return [false];
+  }
+
+  const [, functionName] = identifierOrMemberExpr.split(".");
+
+  return [kTracedFunctionsWithArgIndex.has(functionName), functionName];
+}
+
+function initialize(ctx: ProbeContext) {
+  const { tracer } = ctx.sourceFile;
+
+  for (const functionName of kTracedFunctionsWithArgIndex.keys()) {
+    tracer.trace(`${kModuleName}.${functionName}`, {
+      followConsecutiveAssignment: true,
+      moduleName: kModuleName
+    });
+  }
+}
+
+function main(
+  node: ESTree.CallExpression,
+  ctx: ProbeMainContext
+) {
+  const { sourceFile } = ctx;
+  const { tracer } = sourceFile;
+  const argIndex = kTracedFunctionsWithArgIndex.get(ctx.data as string)!;
+  const arg = node.arguments.at(argIndex);
+
+  if (isNumericLiteral(arg)) {
+    if (arg.value < kMinRounds) {
+      sourceFile.warnings.push(
+        generateWarning("weak-bcrypt", {
+          value: "low-work-factor",
+          location: node.loc
+        })
+      );
+    }
+  }
+  else if (arg?.type === "Identifier") {
+    const literal = tracer.literalIdentifiers.get(arg.name);
+    const numValue = Number(literal?.value);
+    if (!Number.isNaN(numValue) && numValue < kMinRounds) {
+      sourceFile.warnings.push(
+        generateWarning("weak-bcrypt", {
+          value: "low-work-factor",
+          location: node.loc
+        })
+      );
+    }
+  }
+  else if (isLiteral(arg)) {
+    sourceFile.warnings.push(
+      generateWarning("weak-bcrypt", {
+        value: "hardcoded-salt",
+        location: node.loc
+      })
+    );
+  }
+}
+
+export default {
+  name: "isWeakBcrypt",
+  nodeTypes: ["CallExpression"],
+  validateNode,
+  main,
+  initialize,
+  breakOnMatch: false,
+  context: {}
+};

--- a/workspaces/js-x-ray/src/probes/isWeakBcrypt.ts
+++ b/workspaces/js-x-ray/src/probes/isWeakBcrypt.ts
@@ -4,12 +4,12 @@ import type { ESTree } from "meriyah";
 // Import Internal Dependencies
 import type { ProbeContext, ProbeMainContext } from "../ProbeRunner.ts";
 import { CALL_EXPRESSION_DATA } from "../contants.ts";
-import { isLiteral } from "../estree/types.ts";
+import { isLiteral, isNumericLiteral } from "../estree/types.ts";
 import { generateWarning } from "../warnings.ts";
 
 const kMinRounds = 10;
 
-const kModuleName = "bcrypt";
+const kModuleName = "bcryptjs";
 
 // Maps a traced bcrypt function name to the argument index
 const kTracedFunctionsWithArgIndex = new Map([
@@ -18,14 +18,6 @@ const kTracedFunctionsWithArgIndex = new Map([
   ["genSalt", 0],
   ["genSaltSync", 0]
 ]);
-
-function isNumericLiteral(
-  node: unknown
-): node is ESTree.Literal & { value: number; } {
-  return Boolean(node) &&
-    (node as ESTree.Node).type === "Literal" &&
-    typeof (node as ESTree.Literal).value === "number";
-}
 
 function validateNode(
   _node: ESTree.Node,

--- a/workspaces/js-x-ray/src/probes/isWeakScrypt.ts
+++ b/workspaces/js-x-ray/src/probes/isWeakScrypt.ts
@@ -4,7 +4,7 @@ import type { ESTree } from "meriyah";
 // Import Internal Dependencies
 import type { ProbeContext } from "../ProbeRunner.ts";
 import { CALL_EXPRESSION_DATA } from "../contants.ts";
-import { isLiteral } from "../estree/types.ts";
+import { isLiteral, isNumericLiteral } from "../estree/types.ts";
 import { generateWarning } from "../warnings.ts";
 
 /**
@@ -39,8 +39,7 @@ function extractNumericParam(
     if (
       prop.key.type === "Identifier" &&
       names.includes(prop.key.name) &&
-      prop.value.type === "Literal" &&
-      typeof prop.value.value === "number"
+      isNumericLiteral(prop.value)
     ) {
       return prop.value.value;
     }

--- a/workspaces/js-x-ray/src/warnings.ts
+++ b/workspaces/js-x-ray/src/warnings.ts
@@ -14,7 +14,8 @@ export type OptionalWarningName =
   | "log-usage"
   | "insecure-random"
   | "weak-scrypt"
-  | "unsafe-prehash";
+  | "unsafe-prehash"
+  | "weak-bcrypt";
 
 export type WarningName =
   | "parsing-error"
@@ -157,6 +158,11 @@ export const warnings = Object.freeze({
   },
   "unsafe-prehash": {
     i18n: "sast_warnings.unsafe_prehash",
+    severity: "Warning",
+    experimental: true
+  },
+  "weak-bcrypt": {
+    i18n: "sast_warnings.weak_bcrypt",
     severity: "Warning",
     experimental: true
   },

--- a/workspaces/js-x-ray/test/probes/isWeakBcrypt.spec.ts
+++ b/workspaces/js-x-ray/test/probes/isWeakBcrypt.spec.ts
@@ -1,0 +1,221 @@
+// Import Node.js Dependencies
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+// Import Internal Dependencies
+import { AstAnalyser } from "../../src/index.ts";
+
+describe("isWeakBcrypt", () => {
+  describe("low-work-factor", () => {
+    it("should warn when bcrypt.hashSync rounds are below the OWASP minimum (< 10)", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        const hash = bcrypt.hashSync(password, 4);
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-work-factor");
+    });
+
+    it("should warn when bcrypt.genSalt rounds are below the OWASP minimum (< 10)", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        const salt = bcrypt.genSalt(8, (err, salt) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-work-factor");
+    });
+
+    it("should warn when bcrypt.genSaltSync rounds are below the OWASP minimum (< 10)", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        const salt = bcrypt.genSaltSync(8);
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-work-factor");
+    });
+
+    it("should warn when bcryptjs is imported as a namespace (import * as bcrypt)", () => {
+      const code = `
+        import * as bcrypt from 'bcryptjs';
+        bcrypt.hash(password, 4, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-work-factor");
+    });
+
+    it("should warn when bcryptjs.hash is imported as a named import", () => {
+      const code = `
+        import { hash } from 'bcryptjs';
+        hash(password, 4, (err, h) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-work-factor");
+    });
+
+    it("should warn when rounds are stored in a constant with a low literal value", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        const ROUNDS = 4;
+        bcrypt.hash(password, ROUNDS, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-work-factor");
+    });
+
+    it("should warn when rounds are exactly 9 (one below the OWASP minimum)", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        bcrypt.hash(password, 9, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "weak-bcrypt");
+      assert.strictEqual(outputWarnings[0].value, "low-work-factor");
+    });
+
+    it("should not warn when rounds meet the OWASP minimum (>= 10)", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        bcrypt.hash(password, 12, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when rounds are exactly 10 (the OWASP minimum)", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        bcrypt.hash(password, 10, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+
+  describe("hardcoded-salt", () => {
+    it("should warn when a hardcoded salt string is passed to bcrypt.hash", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        bcrypt.hash(password, "$2b$10$N9qo8uLOickgx2ZMRZoMye", (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "weak-bcrypt");
+      assert.strictEqual(outputWarnings[0].value, "hardcoded-salt");
+    });
+
+    it("should warn when a hardcoded salt string is passed to bcrypt.hashSync", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        const hash = bcrypt.hashSync(password, "$2b$10$N9qo8uLOickgx2ZMRZoMye");
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "hardcoded-salt");
+    });
+  });
+
+  describe("no warning (proper usage)", () => {
+    it("should not warn when rounds are a variable", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        bcrypt.hash(password, rounds, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when salt comes from a generated value", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        const salt = bcrypt.genSaltSync(12);
+        bcrypt.hash(password, salt, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when bcryptjs module is not imported", () => {
+      const code = `
+        const bcrypt = { hash() {} };
+        bcrypt.hash(password, 4, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+
+  describe("known limitations", () => {
+    it("should not warn for the less used bcrypt package (only bcryptjs is supported)", () => {
+      const code = `
+        import bcrypt from 'bcrypt';
+        bcrypt.hash(password, 4, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["weak-bcrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+
+  describe("optional warning behavior", () => {
+    it("should NOT report warnings when weak-bcrypt is not enabled", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        bcrypt.hash(password, 4, (err, hash) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser().analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
Adds an optional weak-bcrypt probe to detect insecure hash round or salt usage.

Partially complete https://github.com/NodeSecure/js-x-ray/issues/506