### PR TITLE
feat(probe): detect hash shucking

### DIFF
--- a/.changeset/silent-wolves-occur.md
+++ b/.changeset/silent-wolves-occur.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/js-x-ray": minor
+---
+
+feat(probe): detect hash shucking from crypto pkg

--- a/docs/password-shucking.md
+++ b/docs/password-shucking.md
@@ -1,0 +1,76 @@
+# Password shucking
+
+| Code | Severity | i18n | Experimental |
+| --- | --- | --- | :-: |
+| password-shucking | `Warning` | `sast_warnings.password_shucking` | :white_check_mark: |
+
+## Introduction
+
+Detect **password shucking** — using a plain cryptographic hash (`crypto.createHash`) to pre-hash a password before passing it to [`bcryptjs`](https://www.npmjs.com/package/bcryptjs)'s `bcrypt.hash()` / `bcrypt.hashSync()`.
+
+Only `bcryptjs` is covered. Extending this probe to also cover the `bcrypt` native package is a separate work.
+
+## What is password shucking?
+
+Password shucking exploits the mathematical equivalence:
+
+```
+bcrypt(base64(H(password)), salt, cost) == bcrypt(base64(leaked_hash), salt, cost)
+```
+
+If the inner hash function `H` (e.g. SHA-512) is deterministic and keyless, an attacker who obtains a bcrypt hash can reduce cracking to simply breaking `H`. Testing a dictionary entry costs only one SHA-512 invocation, not a full bcrypt operation. The effective security is identical to storing a raw SHA-512 hash. bcrypt's cost factor provides no additional protection.
+
+The attack requires a known leaked hash. Using a **pepper** via `crypto.createHmac` prevents shucking because the key is unknown to the attacker.
+
+See [OWASP Password Storage Cheat Sheet — bcrypt](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#bcrypt).
+
+## What is detected
+
+A `crypto.createHash` digest passed as the first argument to `bcryptjs.hash` or `bcryptjs.hashSync`, either inline or via a variable, regardless of the digest encoding, since shuckability is encoding-independent.
+
+`crypto.createHmac` (HMAC with a pepper) is **not** flagged; it is the OWASP-recommended mitigation.
+
+## Examples
+
+```js
+import bcrypt from "bcryptjs";
+import crypto from "crypto";
+
+// shucking: SHA-512 pre-hash is as weak as a raw SHA-512 hash
+bcrypt.hash(crypto.createHash("sha512").update(password).digest("base64"), salt, callback);
+
+// shucking: encoding does not matter, hex is still shuckable
+bcrypt.hash(crypto.createHash("sha512").update(password).digest("hex"), salt, callback);
+
+// shucking: same issue when the digest is stored in a variable first
+const prehashed = crypto.createHash("sha512").update(password).digest("hex");
+bcrypt.hash(prehashed, salt, callback);
+
+// safe: HMAC with a pepper, the OWASP-recommended pattern
+bcrypt.hash(crypto.createHmac("sha512", pepper).update(password).digest("base64"), salt, callback);
+
+// safe: no pre-hashing at all
+bcrypt.hash(password, salt, callback);
+```
+
+## Limitations
+
+- **The `bcrypt` package is not detected.** Only `bcryptjs` is supported.
+
+- **Renamed named imports aren't recognized.** This is a `VariableTracer` limitation.
+
+  ```js
+  // not detected: aliased via "as"
+  import { hash as bcryptHash } from "bcryptjs";
+  bcryptHash(crypto.createHash("sha512").update(password).digest(), salt, callback);
+  ```
+
+## Relationship to `unsafe-prehash`
+
+Both probes target `bcryptjs` pre-hashing, but detect different vulnerabilities:
+
+| | `unsafe-prehash` | `password-shucking` |
+|---|---|---|
+| Trigger | Unsafe encoding (null-byte truncation risk) | Any `createHash` digest (shuckable regardless of encoding) |
+| `digest('hex')` → bcrypt | Not flagged (safe encoding) | Flagged (still shuckable) |
+| `createHmac` chains | Flagged (if unsafe encoding) | Not flagged (OWASP-safe pattern) |

--- a/workspaces/js-x-ray/README.md
+++ b/workspaces/js-x-ray/README.md
@@ -127,7 +127,8 @@ type OptionalWarningName =
   | "log-usage"
   | "weak-scrypt"
   | "unsafe-prehash"
-  | "weak-bcrypt";
+  | "weak-bcrypt"
+  | "password-shucking";
 
 type WarningName =
   | "parsing-error"
@@ -192,6 +193,7 @@ The following warnings are optional:
 - `weak-scrypt` - Detects weak scrypt parameters (low cost, short or hardcoded salt)
 - `unsafe-prehash` - Detects password pre-hashing fed into bcrypt without a safe (base64/hex) digest encoding
 - `weak-bcrypt` - Detects weak bcrypt parameters (low work factor, hardcoded salt)
+- `password-shucking` - Detects password pre-hashing with a plain hash function fed into bcrypt
 
 ### Internationalization (i18n)
 
@@ -241,6 +243,7 @@ Click on the warning **name** for detailed documentation and examples.
 | [weak-scrypt](https://github.com/NodeSecure/js-x-ray/blob/master/docs/weak-scrypt.md) ⚠️ | **Yes** | Usage of weak scrypt parameters (low cost, short or hardcoded salt) |
 | [unsafe-prehash](https://github.com/NodeSecure/js-x-ray/blob/master/docs/unsafe-prehash.md) ⚠️ | **Yes** | Password pre-hashed and fed into bcrypt without a safe digest encoding |
 | [weak-bcrypt](https://github.com/NodeSecure/js-x-ray/blob/master/docs/weak-bcrypt.md) ⚠️ | **Yes** | Usage of weak bcrypt parameters (low work factor or hardcoded salt) |
+| [password-shucking](https://github.com/NodeSecure/js-x-ray/blob/master/docs/password-shucking.md) ⚠️ | **Yes** | Password pre-hashed with a plain hash function |
 | [unsafe-vm-context](https://github.com/NodeSecure/js-x-ray/blob/master/docs/unsafe-vm-context.md) ⚠️ | No | Usage of dangerous vm.runInNewContext and (vm.Script(code,options)).runInContext |
 
 #### Information Severity

--- a/workspaces/js-x-ray/src/ProbeRunner.ts
+++ b/workspaces/js-x-ray/src/ProbeRunner.ts
@@ -29,6 +29,7 @@ import isPrototypePollution from "./probes/isPrototypePollution.ts";
 import isWeakScrypt from "./probes/isWeakScrypt.ts";
 import isUnsafePrehash from "./probes/isUnsafePrehash.ts";
 import isWeakBcrypt from "./probes/isWeakBcrypt.ts";
+import isPasswordShucking from "./probes/isPasswordShucking.ts";
 
 import type { TracedIdentifierReport } from "./VariableTracer.ts";
 import type { SourceFile } from "./SourceFile.ts";
@@ -132,7 +133,8 @@ export class ProbeRunner {
     "insecure-random": isRandom,
     "weak-scrypt": isWeakScrypt,
     "unsafe-prehash": isUnsafePrehash,
-    "weak-bcrypt": isWeakBcrypt
+    "weak-bcrypt": isWeakBcrypt,
+    "password-shucking": isPasswordShucking
   };
 
   constructor(

--- a/workspaces/js-x-ray/src/estree/functions/getParamNames.ts
+++ b/workspaces/js-x-ray/src/estree/functions/getParamNames.ts
@@ -1,0 +1,19 @@
+// Import Third-party Dependencies
+import type { ESTree } from "meriyah";
+
+// Import Internal Dependencies
+import { getVariableDeclarationIdentifiers } from "./getVariableDeclarationIdentifiers.ts";
+
+export function getParamNames(
+  params: ESTree.Node[]
+): string[] {
+  const names: string[] = [];
+
+  for (const param of params) {
+    for (const { assignmentId } of getVariableDeclarationIdentifiers(param)) {
+      names.push(assignmentId.name);
+    }
+  }
+
+  return names;
+}

--- a/workspaces/js-x-ray/src/estree/index.ts
+++ b/workspaces/js-x-ray/src/estree/index.ts
@@ -5,6 +5,7 @@ export * from "./functions/extractLogicalExpression.ts";
 export * from "./functions/getCallExpressionArguments.ts";
 export * from "./functions/getCallExpressionIdentifier.ts";
 export * from "./functions/getMemberExpressionIdentifier.ts";
+export * from "./functions/getParamNames.ts";
 export * from "./functions/getVariableDeclarationIdentifiers.ts";
 export * from "./functions/toLiteral.ts";
 export * from "./types.ts";

--- a/workspaces/js-x-ray/src/estree/types.ts
+++ b/workspaces/js-x-ray/src/estree/types.ts
@@ -75,6 +75,18 @@ export function isCallExpression(
   return isNode(node) && node.type === "CallExpression";
 }
 
+export function isIdentifier(
+  node: unknown
+): node is ESTree.Identifier {
+  return isNode(node) && node.type === "Identifier";
+}
+
+export function isMemberExpression(
+  node: unknown
+): node is ESTree.MemberExpression {
+  return isNode(node) && node.type === "MemberExpression";
+}
+
 export interface DefaultOptions {
   externalIdentifierLookup?(name: string): string | null;
 }

--- a/workspaces/js-x-ray/src/probes/isPasswordShucking.ts
+++ b/workspaces/js-x-ray/src/probes/isPasswordShucking.ts
@@ -1,0 +1,173 @@
+// Import Third-party Dependencies
+import type { ESTree } from "meriyah";
+
+// Import Internal Dependencies
+import type { ProbeContext, ProbeMainContext } from "../ProbeRunner.ts";
+import { CALL_EXPRESSION_DATA } from "../contants.ts";
+import { isCallExpression, isFunctionNode, isIdentifier, isMemberExpression } from "../estree/types.ts";
+import { getParamNames, getMemberCallExpression } from "../estree/index.ts";
+import { generateWarning } from "../warnings.ts";
+import {
+  VariableTracer,
+  type ReturnValueEventPayload
+} from "../VariableTracer.ts";
+
+const kModuleName = "bcryptjs";
+const kTracedFunctions = new Set(["bcryptjs.hash", "bcryptjs.hashSync"]);
+
+const kShuckingVariables = Symbol("shuckingVariables");
+const kAmbiguousVariableNames = Symbol("ambiguousVariableNames");
+
+interface PasswordShuckingContext {
+  [kShuckingVariables]?: Set<string>;
+  [kAmbiguousVariableNames]?: Set<string>;
+}
+
+/**
+ * createHmac is intentionally excluded, HMAC with a pepper is the OWASP-safe pattern.
+ */
+const kHashDigestChains = [
+  "crypto.createHash.update.digest",
+  "crypto.createHash.update.digest.toString",
+  "crypto.createHash.digest",
+  "crypto.createHash.digest.toString"
+] as const;
+
+function isCreateHashChain(node: ESTree.Node | null | undefined): boolean {
+  let current = node;
+  while (isCallExpression(current)) {
+    const { callee } = current;
+    if (!isMemberExpression(callee)) {
+      break;
+    }
+    if (isIdentifier(callee.property) && callee.property.name === "createHash") {
+      return true;
+    }
+    current = callee.object;
+  }
+
+  return false;
+}
+
+function hasDigestChain(hashNode: ESTree.Node | null | undefined): boolean {
+  if (getMemberCallExpression(hashNode, "digest") !== null) {
+    return true;
+  }
+  const toStringCall = getMemberCallExpression(hashNode, "toString");
+  if (toStringCall) {
+    return getMemberCallExpression(toStringCall.callee.object, "digest") !== null;
+  }
+
+  return false;
+}
+
+function isShuckingPrehash(hashNode: ESTree.Node | null | undefined): boolean {
+  return hasDigestChain(hashNode) && isCreateHashChain(hashNode);
+}
+
+type NodeValidationResult = [false] | [true] | [true, string[]];
+
+function validateNode(
+  node: ESTree.Node,
+  ctx: ProbeContext<PasswordShuckingContext>
+): NodeValidationResult {
+  const { tracer } = ctx.sourceFile;
+
+  if (!tracer.importedModules.has(kModuleName) || !tracer.importedModules.has("crypto")) {
+    return [false];
+  }
+
+  if (isFunctionNode(node)) {
+    const paramNames = getParamNames(node.params);
+    const shuckingVars = ctx.context![kShuckingVariables]!;
+
+    if (paramNames.some((name) => shuckingVars.has(name))) {
+      ctx.setEntryPoint("markAmbiguousParams");
+
+      return [true, paramNames];
+    }
+
+    return [false];
+  }
+
+  return [kTracedFunctions.has(ctx.context![CALL_EXPRESSION_DATA]?.identifierOrMemberExpr)];
+}
+
+function initialize(ctx: ProbeContext<PasswordShuckingContext>) {
+  const { tracer } = ctx.sourceFile;
+
+  ctx.context![kShuckingVariables] = new Set<string>();
+  ctx.context![kAmbiguousVariableNames] = new Set<string>();
+
+  for (const fn of kTracedFunctions) {
+    tracer.trace(fn, {
+      followConsecutiveAssignment: true,
+      moduleName: kModuleName
+    });
+  }
+
+  for (const chain of kHashDigestChains) {
+    tracer.trace(chain, {
+      followReturnValueAssignement: true,
+      followConsecutiveAssignment: true,
+      moduleName: "crypto"
+    });
+  }
+
+  tracer.on(VariableTracer.ReturnValueEvent, (payload: ReturnValueEventPayload) => {
+    if (!(kHashDigestChains as readonly string[]).includes(payload.identifierOrMemberExpr)) {
+      return;
+    }
+
+    ctx.context![kShuckingVariables]!.add(payload.id);
+  });
+}
+
+function markAmbiguousParams(
+  _node: ESTree.Node,
+  ctx: ProbeMainContext<PasswordShuckingContext>
+) {
+  for (const name of ctx.data as string[]) {
+    ctx.context![kAmbiguousVariableNames]!.add(name);
+  }
+}
+
+function bcryptHashCall(
+  bcryptNode: ESTree.CallExpression,
+  ctx: ProbeMainContext<PasswordShuckingContext>
+) {
+  const hashArgument = bcryptNode.arguments.at(0);
+  const ambiguousVars = ctx.context![kAmbiguousVariableNames]!;
+  const shuckingVars = ctx.context![kShuckingVariables]!;
+
+  const isVariableShucking = isIdentifier(hashArgument) &&
+    !ambiguousVars.has(hashArgument.name) &&
+    shuckingVars.has(hashArgument.name);
+
+  if (isVariableShucking || isShuckingPrehash(hashArgument)) {
+    ctx.sourceFile.warnings.push(
+      generateWarning("password-shucking", {
+        value: null,
+        location: bcryptNode.loc
+      })
+    );
+  }
+}
+
+export default {
+  name: "isPasswordShucking",
+  nodeTypes: [
+    "CallExpression",
+    "FunctionDeclaration",
+    "FunctionExpression",
+    "ArrowFunctionExpression"
+  ],
+  validateNode,
+  main: {
+    default: bcryptHashCall,
+    markAmbiguousParams
+  },
+  initialize,
+  breakOnMatch: false,
+  context: {}
+};

--- a/workspaces/js-x-ray/src/probes/isUnsafePrehash.ts
+++ b/workspaces/js-x-ray/src/probes/isUnsafePrehash.ts
@@ -4,8 +4,8 @@ import type { ESTree } from "meriyah";
 // Import Internal Dependencies
 import type { ProbeContext, ProbeMainContext } from "../ProbeRunner.ts";
 import { CALL_EXPRESSION_DATA } from "../contants.ts";
-import { isLiteral, isFunctionNode } from "../estree/types.ts";
-import { getVariableDeclarationIdentifiers, getMemberCallExpression } from "../estree/index.ts";
+import { isLiteral, isFunctionNode, isIdentifier, isCallExpression } from "../estree/types.ts";
+import { getParamNames, getMemberCallExpression } from "../estree/index.ts";
 import { generateWarning } from "../warnings.ts";
 import {
   VariableTracer,
@@ -75,20 +75,6 @@ function resolveDigestEncodingArguments(
   return null;
 }
 
-function getParamNames(
-  params: ESTree.Node[]
-): string[] {
-  const names: string[] = [];
-
-  for (const param of params) {
-    for (const { assignmentId } of getVariableDeclarationIdentifiers(param)) {
-      names.push(assignmentId.name);
-    }
-  }
-
-  return names;
-}
-
 function isSafeEncodingArg(
   node: ESTree.Node | undefined,
   literalIdentifiers: Map<string, LiteralIdentifier>
@@ -97,7 +83,7 @@ function isSafeEncodingArg(
     return kSafeDigestEncodings.has(node.value);
   }
 
-  if (node?.type === "Identifier") {
+  if (isIdentifier(node)) {
     const literal = literalIdentifiers.get(node.name);
 
     return literal !== undefined && kSafeDigestEncodings.has(literal.value);
@@ -202,15 +188,15 @@ function bcryptHashCall(
   const hashArgument = bcryptNode.arguments.at(0);
 
   let isUnsafe: boolean;
-  if (hashArgument?.type === "Identifier") {
+  if (isIdentifier(hashArgument)) {
     const isAmbiguous = getContextSet(ctx, kAmbiguousVariableNames).has(hashArgument.name);
     const isDigestVariable = getContextSet(ctx, kUnsafeDigestVariables).has(hashArgument.name);
 
     isUnsafe = !isAmbiguous && isDigestVariable;
   }
   else if (
-    hashArgument?.type === "CallExpression" &&
-    hashArgument.callee.type === "Identifier" &&
+    isCallExpression(hashArgument) &&
+    isIdentifier(hashArgument.callee) &&
     !getContextSet(ctx, kAmbiguousVariableNames).has(hashArgument.callee.name) &&
     getContextSet(ctx, kUnsafeDigestVariables).has(hashArgument.callee.name)
   ) {

--- a/workspaces/js-x-ray/src/warnings.ts
+++ b/workspaces/js-x-ray/src/warnings.ts
@@ -15,7 +15,8 @@ export type OptionalWarningName =
   | "insecure-random"
   | "weak-scrypt"
   | "unsafe-prehash"
-  | "weak-bcrypt";
+  | "weak-bcrypt"
+  | "password-shucking";
 
 export type WarningName =
   | "parsing-error"
@@ -163,6 +164,11 @@ export const warnings = Object.freeze({
   },
   "weak-bcrypt": {
     i18n: "sast_warnings.weak_bcrypt",
+    severity: "Warning",
+    experimental: true
+  },
+  "password-shucking": {
+    i18n: "sast_warnings.password_shucking",
     severity: "Warning",
     experimental: true
   },

--- a/workspaces/js-x-ray/test/probes/isPasswordShucking.spec.ts
+++ b/workspaces/js-x-ray/test/probes/isPasswordShucking.spec.ts
@@ -1,0 +1,62 @@
+// Import Node.js Dependencies
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+// Import Internal Dependencies
+import { AstAnalyser } from "../../src/index.ts";
+
+const kOptions = { optionalWarnings: ["password-shucking"] as const };
+
+describe("isPasswordShucking probe", () => {
+  it("should warn regardless of encoding, shuckability is independent of digest encoding", () => {
+    for (const encoding of ["", "'hex'", "'base64'", "'base64url'", "'binary'"]) {
+      const arg = encoding ? `digest(${encoding})` : "digest()";
+      const code = `
+          import bcrypt from 'bcryptjs';
+          import crypto from 'crypto';
+          bcrypt.hash(crypto.createHash('sha256').update(password).${arg}, salt, (err, hash) => {});
+        `;
+      const { warnings } = new AstAnalyser(kOptions).analyse(code);
+
+      assert.strictEqual(warnings.length, 1, `Expected warning for encoding: ${encoding || "none"}`);
+      assert.strictEqual(warnings[0].kind, "password-shucking");
+    }
+  });
+
+  it("should warn when a createHash digest with a safe encoding is stored in a variable (unique to this probe)", () => {
+    const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        const prehashed = crypto.createHash('sha512').update(password).digest('hex');
+        bcrypt.hash(prehashed, salt, (err, hash) => {});
+      `;
+    const { warnings } = new AstAnalyser(kOptions).analyse(code);
+
+    assert.strictEqual(warnings.length, 1);
+    assert.strictEqual(warnings[0].kind, "password-shucking");
+  });
+
+  it("should not warn when createHmac is used, pepper prevents hash enumeration", () => {
+    const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHmac('sha512', pepper).update(password).digest('base64'), salt, (err, hash) => {});
+      `;
+    const { warnings } = new AstAnalyser(kOptions).analyse(code);
+
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  describe("optional warning behavior", () => {
+    it("should not report when password-shucking is not enabled", () => {
+      const code = `
+        import bcrypt from 'bcryptjs';
+        import crypto from 'crypto';
+        bcrypt.hash(crypto.createHash('sha256').update(password).digest('hex'), salt, (err, hash) => {});
+      `;
+      const { warnings } = new AstAnalyser().analyse(code);
+
+      assert.strictEqual(warnings.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
Adds an optional hash shucking detection probe.

Partially complete https://github.com/NodeSecure/js-x-ray/issues/506
May closes the bcrypt chapter.