### PR TITLE
feat(tracer): resolve identifiers assigned an object literal

### DIFF
--- a/.changeset/quiet-otters-listen.md
+++ b/.changeset/quiet-otters-listen.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/js-x-ray": minor
+---
+
+feat(tracer): resolve identifiers assigned an object literal, so `log-usage` detects `pino()`/`winston.createLogger()` config passed via a variable instead of only inline

--- a/workspaces/js-x-ray/src/VariableTracer.ts
+++ b/workspaces/js-x-ray/src/VariableTracer.ts
@@ -148,6 +148,13 @@ export class VariableTracer extends EventEmitter {
 
   // PUBLIC PROPERTIES
   literalIdentifiers = new Map<string, LiteralIdentifier>();
+  /**
+   * Resolves an identifier assigned an object literal back to its ObjectExpression node.
+   * @example
+   * const opts = { useOnlyCustomLevels: true };
+   * pino(opts); // "opts" resolves via objectIdentifiers
+   */
+  objectIdentifiers = new Map<string, ESTree.ObjectExpression>();
   importedModules = new Set<string>();
 
   // PRIVATE PROPERTIES
@@ -494,6 +501,12 @@ export class VariableTracer extends EventEmitter {
        * ^ ObjectExpression
        */
       case "ObjectExpression": {
+        // Only record top-level assignments (`const x = {...}`) so consumers
+        // can resolve "x" back to its object shape, e.g. `pino(x)`.
+        if (childNode === variableDeclaratorNode.init) {
+          this.objectIdentifiers.set(id.name, childNode);
+        }
+
         for (const property of childNode.properties) {
           let node: ESTree.Node | null = null;
           if (property.type === "Property") {

--- a/workspaces/js-x-ray/src/probes/log-usage.ts
+++ b/workspaces/js-x-ray/src/probes/log-usage.ts
@@ -123,7 +123,10 @@ function createWinstonCreateLoggerTracerListener(tracer: VariableTracer, logUsag
     let winstonLoggerMethods = winstonCreateLoggerChildLoggerFunctions.get(payload.name) ?? [...kWinstonLogMethods];
 
     winston: if (payload.name === "winston.createLogger") {
-      const winstonContext = payload.arguments[0];
+      const winstonContextArg = payload.arguments[0];
+      const winstonContext = winstonContextArg && isIdentifier(winstonContextArg) ?
+        tracer.objectIdentifiers.get(winstonContextArg.name) :
+        winstonContextArg;
       if (!winstonContext || winstonContext.type !== "ObjectExpression") {
         break winston;
       }
@@ -174,7 +177,10 @@ function createPinoTracerListener(tracer: VariableTracer, logUsages: Set<string>
     let pinoLoggerMethods: string[] = pinoLoggerChildLoggerFunctions.get(payload.name) ?? [...kPinoLogMethods];
 
     pino: if (payload.name === "pino") {
-      const pinoContext = payload.arguments[0];
+      const pinoContextArg = payload.arguments[0];
+      const pinoContext = pinoContextArg && isIdentifier(pinoContextArg) ?
+        tracer.objectIdentifiers.get(pinoContextArg.name) :
+        pinoContextArg;
       if (!pinoContext || pinoContext.type !== "ObjectExpression") {
         break pino;
       }

--- a/workspaces/js-x-ray/test/VariableTracer/assignments.spec.ts
+++ b/workspaces/js-x-ray/test/VariableTracer/assignments.spec.ts
@@ -157,6 +157,29 @@ test("it should be able to Trace template literals who has being assigned", () =
   });
 });
 
+test("it should be able to resolve an identifier assigned an object literal", () => {
+  const helpers = createTracer();
+
+  helpers.walkOnCode(`
+    const opts = { useOnlyCustomLevels: true, foo: "bar" };
+  `);
+  assert.ok(helpers.tracer.objectIdentifiers.has("opts"));
+
+  const objectNode = helpers.tracer.objectIdentifiers.get("opts")!;
+  assert.strictEqual(objectNode.type, "ObjectExpression");
+  assert.strictEqual(objectNode.properties.length, 2);
+});
+
+test("it should not resolve a non top-level object literal as an identifier", () => {
+  const helpers = createTracer();
+
+  helpers.walkOnCode(`
+    const opts = { nested: { useOnlyCustomLevels: true } };
+  `);
+  assert.ok(helpers.tracer.objectIdentifiers.has("opts"));
+  assert.strictEqual(helpers.tracer.objectIdentifiers.has("nested"), false);
+});
+
 test("it should be able to Trace a global assignment using a LogicalExpression", () => {
   const helpers = createTracer(true);
   const assignments = helpers.getAssignmentArray();

--- a/workspaces/js-x-ray/test/probes/log-usage.spec.ts
+++ b/workspaces/js-x-ray/test/probes/log-usage.spec.ts
@@ -383,6 +383,33 @@ describe("log-usage probe", () => {
         assert.strictEqual(firstWarning.value, "logger.foo, logger.bar");
       });
 
+      it("should resolve the whole pino() config object when passed as an identifier", () => {
+        const code = `import pino from "pino";
+
+                    const opts = {
+                    customLevels:{
+                      foo: 35,
+                      bar: 36
+                      },
+                    useOnlyCustomLevels: true,
+                    };
+                    const logger = pino(opts);
+                    logger.info("hello");
+                    logger.warn("hello");
+                    logger.foo("hello");
+                    logger.bar("hello");
+                    `;
+        const { warnings } = new AstAnalyser({
+          optionalWarnings: true
+        }).analyse(code);
+
+        const [firstWarning] = warnings;
+
+        assert.strictEqual(firstWarning.kind, "log-usage");
+        assert.strictEqual(firstWarning.severity, "Information");
+        assert.strictEqual(firstWarning.value, "logger.foo, logger.bar");
+      });
+
       it("should trace default methods as well when useOnlyCustomLevels is false", () => {
         const code = `import pino from "pino";
                     const logger = pino({
@@ -861,6 +888,35 @@ describe("log-usage probe", () => {
                     logger.verbose("hello");
                     logger.silly("hello");
                     logger.log({level: "info", message: "hello"});
+                    logger.foo("hello");
+                    logger.bar("hello");
+                    `;
+
+            const { warnings } = new AstAnalyser({
+              optionalWarnings: true
+            }).analyse(code);
+
+            const [firstWarning] = warnings;
+
+            assert.strictEqual(firstWarning.kind, "log-usage");
+            assert.strictEqual(firstWarning.severity, "Information");
+            assert.strictEqual(firstWarning.value, "logger.foo, logger.bar");
+          });
+
+          it("should resolve the whole winston.createLogger() config object when passed as an identifier", () => {
+            const code = `const winston = require("winston");
+                    const opts = {
+                      format: winston.format.json(),
+                      transports: [new winston.transports.Console()],
+                      levels: {
+                         foo: 1,
+                         bar: 2
+                        }
+                      };
+                    const logger = winston.createLogger(opts);
+
+                    logger.info("hello");
+                    logger.warn("hello");
                     logger.foo("hello");
                     logger.bar("hello");
                     `;


### PR DESCRIPTION
## Summary

Closes #639.

`VariableTracer` can resolve an identifier back to its value for `Literal` and `TemplateLiteral` initializers (`literalIdentifiers`), but not for an identifier assigned an object literal:

```js
const x = "hello";      // resolvable via literalIdentifiers
const y = { a: 1 };     // NOT resolvable back to its ObjectExpression
```

This has a concrete effect on the `log-usage` probe: `pino()` and `winston.createLogger()` config detection (`customLevels`, `useOnlyCustomLevels`, `levels`) only works when the config object is passed **inline**:

```js
pino({ customLevels: { foo: 35 }, useOnlyCustomLevels: true }); // detected correctly
```

but silently falls through to the default method list (or, for `winston.createLogger`, produces no warning at all) when the same object is passed via a variable, which is an extremely common pattern:

```js
const opts = { customLevels: { foo: 35 }, useOnlyCustomLevels: true };
pino(opts); // before this PR: treated as if it had no config at all
```

## Changes

- `VariableTracer.ts`: add a new public `objectIdentifiers: Map<string, ESTree.ObjectExpression>`, populated in the existing `ObjectExpression` branch of `#walkVariableDeclaratorInitialization` for top-level assignments only (`const x = {...}`, not nested object values), mirroring how `literalIdentifiers` is populated for `Literal`/`TemplateLiteral`.
- `log-usage.ts`: in both `createPinoTracerListener` and `createWinstonCreateLoggerTracerListener`, resolve the config argument via `tracer.objectIdentifiers` when it's an `Identifier` instead of bailing out when it isn't an inline `ObjectExpression`.

I deliberately did not touch `literalIdentifiers` itself (adding an object type there) since its `.value: string` field is consumed as a plain string by several other probes (`sql-injection`, `isRequire`, `isWeakBcrypt`, `isMonkeyPatch`, etc.) — a separate map keeps this change isolated to the object-resolution use case with no risk to existing consumers.

## Tests

- `test/VariableTracer/assignments.spec.ts`: two new tests confirming `objectIdentifiers` is populated for a top-level object literal assignment and correctly *not* populated for a nested object value.
- `test/probes/log-usage.spec.ts`: two new tests (one for `pino()`, one for `winston.createLogger()`) confirming the config-via-variable case now resolves the custom levels correctly. Verified against a version of the fix reverted locally that without it, the pino case falls back to default methods and the winston case produces zero warnings — confirming this is a real, previously-silent gap.

## Verification

```
node --test-reporter=spec --test "./test/VariableTracer/**/*.spec.ts" "./test/probes/log-usage.spec.ts" "./test/probes/sql-injection.spec.ts" "./test/probes/crypto/**/*.spec.ts" "./test/probes/isRequire/**/*.spec.ts" "./test/probes/isMonkeyPatch.spec.ts"
```
All pass (179/179) when run with a `RegExp.escape` polyfill preloaded to work around this sandbox only having Node 22 available (the repo requires Node >=24; I don't have Node 24 in this environment, and confirmed the `RegExp.escape is not a function` failures reproduce identically on a clean `master` checkout — they're unrelated to this change, from an unrelated obfuscator check that fires on every `.analyse()` call).

Full suite on Node 22, no polyfill: 739 tests, 701 pass, 38 fail — same 38 pre-existing `RegExp.escape`-related failures as on a clean `master` checkout (0 new failures from this change). `tsc`/`eslint` also couldn't run locally (both reference private `@openally/config.*` packages not resolvable outside NodeSecure's own setup), so I can't run those two locally either, but neither touches runtime logic.

Added a changeset (`minor`, matching the existing convention for new detection capability).
