### PR TITLE
feat(js-x-ray): add weak-argon2 detection probe

### DIFF
--- a/.changeset/silly-camels-repeat.md
+++ b/.changeset/silly-camels-repeat.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/js-x-ray": minor
+---
+
+Add weak-argon2 detection probe for crypto.argon2() misuse

--- a/docs/crypto.weak-argon2.md
+++ b/docs/crypto.weak-argon2.md
@@ -1,0 +1,105 @@
+# Weak Argon2
+
+| Code | Severity | i18n | Experimental |
+| --- | --- | --- | :-: |
+| crypto.weak-argon2 | `Warning` | `sast_warnings.weak_argon2` | :white_check_mark: |
+
+## Introduction
+
+Detect usage of **weak Argon2** parameters with the Node.js core `crypto.argon2()` and `crypto.argon2Sync()` functions. This probe checks for:
+
+- **weak-algorithm**: the `argon2d` variant, which is data-dependent and not intended for password hashing.
+- **low-params**: `memory` and `passes` that do not meet [OWASP recommended combinations](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id).
+- **short-nonce**: nonce is a hardcoded string literal shorter than 16 characters.
+- **hardcoded-nonce**: nonce is a hardcoded string literal (should be randomly generated).
+
+> [!NOTE]
+> Argon2 calls the salt a **nonce**, and so does the Node.js API. The warning values follow that
+> naming so they match what the analysed source code actually writes.
+
+## Variants
+
+[RFC 9106](https://www.rfc-editor.org/rfc/rfc9106.html#section-4) recommends `argon2id` when in doubt, and describes `argon2d` as suited to applications with no threat from side-channel attacks — which excludes password hashing.
+
+| Variant | Verdict |
+| --- | --- |
+| `argon2d` | Always reported. Data-dependent memory access leaks information through side channels. |
+| `argon2i` | Accepted, but restricted to `passes >= 3` (see below). |
+| `argon2id` | Accepted. |
+
+## Parameters
+
+OWASP publishes five configurations that provide an equal level of defense, trading CPU against RAM. A call is reported when its `memory` and `passes` satisfy none of them.
+
+| memory (KiB) | passes | |
+| --- | --- | --- |
+| 47104 (46 MiB) | 1 | Do not use with Argon2i |
+| 19456 (19 MiB) | 2 | Do not use with Argon2i |
+| 12288 (12 MiB) | 3 | |
+| 9216 (9 MiB) | 4 | |
+| 7168 (7 MiB) | 5 | |
+
+Argon2i is data-independent and therefore weaker against time-memory trade-off attacks, which additional passes mitigate — see [RFC 9106 section 7.3](https://www.rfc-editor.org/rfc/rfc9106.html#section-7.3). The two lowest-pass rows are consequently unavailable to it, so `argon2i` with `passes` below 3 is reported regardless of how much memory is allocated.
+
+`parallelism` is not checked: raising it does not reduce the total memory cost, so it is not a weakness on its own.
+
+Parameters passed as variables are not resolved, and no warning is emitted for them.
+
+## Example
+
+```js
+import crypto from "crypto";
+
+// weak-algorithm: argon2d is not intended for password hashing
+crypto.argon2("argon2d", {
+  message: password,
+  nonce: crypto.randomBytes(16),
+  parallelism: 1,
+  tagLength: 32,
+  memory: 19456,
+  passes: 2
+}, (err, tag) => {});
+
+// low-params: 8 KiB is far below the lowest OWASP row (7168 KiB)
+crypto.argon2("argon2id", {
+  message: password,
+  nonce: crypto.randomBytes(16),
+  parallelism: 1,
+  tagLength: 32,
+  memory: 8,
+  passes: 1
+}, (err, tag) => {});
+
+// low-params: argon2i cannot use the passes=2 row
+crypto.argon2("argon2i", {
+  message: password,
+  nonce: crypto.randomBytes(16),
+  parallelism: 1,
+  tagLength: 32,
+  memory: 19456,
+  passes: 2
+}, (err, tag) => {});
+
+// hardcoded-nonce: the nonce must be randomly generated per password
+crypto.argon2Sync("argon2id", {
+  message: password,
+  nonce: "a]Zz4M]rP7:L<Mwb",
+  parallelism: 1,
+  tagLength: 32,
+  memory: 19456,
+  passes: 2
+});
+```
+
+The following call is not reported.
+
+```js
+crypto.argon2("argon2id", {
+  message: password,
+  nonce: crypto.randomBytes(16),
+  parallelism: 1,
+  tagLength: 32,
+  memory: 19456,
+  passes: 2
+}, (err, tag) => {});
+```

--- a/docs/crypto.weak-argon2.md
+++ b/docs/crypto.weak-argon2.md
@@ -6,12 +6,13 @@
 
 ## Introduction
 
-Detect usage of **weak Argon2** parameters with the Node.js core `crypto.argon2()` and `crypto.argon2Sync()` functions. This probe checks for:
+Detect usage of **weak Argon2** parameters with the Node.js core `crypto.argon2()` and `crypto.argon2Sync()` functions.
+Checks for:
 
-- **weak-algorithm**: the `argon2d` variant, which is data-dependent and not intended for password hashing.
-- **low-params**: `memory` and `passes` that do not meet [OWASP recommended combinations](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id).
-- **short-nonce**: nonce is a hardcoded string literal shorter than 16 characters.
-- **hardcoded-nonce**: nonce is a hardcoded string literal (should be randomly generated).
+- **weak-algorithm: `<variant>`**: the `argon2d` variant, which is data-dependent and not intended for password hashing.
+- **low-params: `memory` | `passes`**: `memory` and `passes` that do not meet [OWASP recommended combinations](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id). The reported name is the parameter that has to change.
+- **short-nonce**: nonce is a hardcoded string shorter than 16 characters.
+- **hardcoded-nonce**: nonce is a hardcoded string (should be randomly generated).
 
 > [!NOTE]
 > Argon2 calls the salt a **nonce**, and so does the Node.js API. The warning values follow that
@@ -43,14 +44,25 @@ Argon2i is data-independent and therefore weaker against time-memory trade-off a
 
 `parallelism` is not checked: raising it does not reduce the total memory cost, so it is not a weakness on its own.
 
-Parameters passed as variables are not resolved, and no warning is emitted for them.
+## Resolving values
+
+The algorithm, `memory`, `passes` and `nonce` may be written inline or held in a variable. Identifiers assigned a literal are followed through the `VariableTracer`, so both forms below are reported.
+
+```js
+crypto.argon2("argon2d", options, callback);
+
+const algorithm = "argon2d";
+crypto.argon2(algorithm, options, callback);
+```
+
+Anything that cannot be read statically — a value computed at runtime, a key computed from a variable, an options object spread from elsewhere — is left alone rather than reported on a value that is unknown.
 
 ## Example
 
 ```js
 import crypto from "crypto";
 
-// weak-algorithm: argon2d is not intended for password hashing
+// weak-algorithm: argon2d — not intended for password hashing
 crypto.argon2("argon2d", {
   message: password,
   nonce: crypto.randomBytes(16),
@@ -60,7 +72,7 @@ crypto.argon2("argon2d", {
   passes: 2
 }, (err, tag) => {});
 
-// low-params: 8 KiB is far below the lowest OWASP row (7168 KiB)
+// low-params: memory — 8 KiB is far below the lowest OWASP row (7168 KiB)
 crypto.argon2("argon2id", {
   message: password,
   nonce: crypto.randomBytes(16),
@@ -70,7 +82,7 @@ crypto.argon2("argon2id", {
   passes: 1
 }, (err, tag) => {});
 
-// low-params: argon2i cannot use the passes=2 row
+// low-params: passes — argon2i cannot use the passes=2 row
 crypto.argon2("argon2i", {
   message: password,
   nonce: crypto.randomBytes(16),

--- a/docs/crypto.weak-argon2.md
+++ b/docs/crypto.weak-argon2.md
@@ -19,7 +19,7 @@ Detect usage of **weak Argon2** parameters with the Node.js core `crypto.argon2(
 
 ## Variants
 
-[RFC 9106](https://www.rfc-editor.org/rfc/rfc9106.html#section-4) recommends `argon2id` when in doubt, and describes `argon2d` as suited to applications with no threat from side-channel attacks — which excludes password hashing.
+[RFC 9106 section 1](https://www.rfc-editor.org/rfc/rfc9106.html#section-1) describes `argon2d` as *"suitable for cryptocurrencies and proof-of-work applications with no threats from side-channel timing attacks"*, and `argon2i` as using data-independent memory access *"which is preferred for password hashing and password-based key derivation"*. [Section 4](https://www.rfc-editor.org/rfc/rfc9106.html#section-4) adds that if you do not know the difference between the types, you should choose `argon2id`.
 
 | Variant | Verdict |
 | --- | --- |

--- a/docs/crypto.weak-argon2.md
+++ b/docs/crypto.weak-argon2.md
@@ -11,7 +11,7 @@ Checks for:
 
 - **weak-algorithm: `<variant>`**: the `argon2d` variant, which is data-dependent and not intended for password hashing.
 - **low-params: `memory` | `passes`**: `memory` and `passes` that do not meet [OWASP recommended combinations](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id). The reported name is the parameter that has to change.
-- **short-nonce**: nonce is a hardcoded string shorter than 16 characters.
+- **short-nonce**: nonce is a hardcoded string shorter than 16 bytes.
 - **hardcoded-nonce**: nonce is a hardcoded string (should be randomly generated).
 
 > [!NOTE]

--- a/docs/crypto.weak-argon2.md
+++ b/docs/crypto.weak-argon2.md
@@ -57,6 +57,8 @@ crypto.argon2(algorithm, options, callback);
 
 Anything that cannot be read statically — a value computed at runtime, a key computed from a variable, an options object spread from elsewhere — is left alone rather than reported on a value that is unknown.
 
+An algorithm that cannot be resolved only skips the variant check: `memory`, `passes` and `nonce` are still verified, against the general OWASP rows since the variant is unknown.
+
 ## Example
 
 ```js

--- a/workspaces/js-x-ray/README.md
+++ b/workspaces/js-x-ray/README.md
@@ -128,7 +128,8 @@ type OptionalWarningName =
   | "crypto.weak-scrypt"
   | "crypto.unsafe-prehash"
   | "crypto.weak-bcrypt"
-  | "crypto.password-shucking";
+  | "crypto.password-shucking"
+  | "crypto.weak-argon2";
 
 type WarningName =
   | "parsing-error"
@@ -199,6 +200,7 @@ The following warnings are optional:
 - `crypto.unsafe-prehash` - Detects password pre-hashing fed into bcrypt without a safe (base64/hex) digest encoding
 - `crypto.weak-bcrypt` - Detects weak bcrypt parameters (low work factor, hardcoded salt)
 - `crypto.password-shucking` - Detects password pre-hashing with a plain hash function fed into bcrypt
+- `crypto.weak-argon2` - Detects weak Argon2 parameters (argon2d variant, low memory/passes, short or hardcoded nonce)
 
 ### Internationalization (i18n)
 
@@ -249,6 +251,7 @@ Click on the warning **name** for detailed documentation and examples.
 | [crypto.unsafe-prehash](https://github.com/NodeSecure/js-x-ray/blob/master/docs/crypto.unsafe-prehash.md) ⚠️ | **Yes** | Password pre-hashed and fed into bcrypt without a safe digest encoding |
 | [crypto.weak-bcrypt](https://github.com/NodeSecure/js-x-ray/blob/master/docs/crypto.weak-bcrypt.md) ⚠️ | **Yes** | Usage of weak bcrypt parameters (low work factor or hardcoded salt) |
 | [crypto.password-shucking](https://github.com/NodeSecure/js-x-ray/blob/master/docs/crypto.password-shucking.md) ⚠️ | **Yes** | Password pre-hashed with a plain hash function |
+| [crypto.weak-argon2](https://github.com/NodeSecure/js-x-ray/blob/master/docs/crypto.weak-argon2.md) ⚠️ | **Yes** | Usage of weak Argon2 parameters (argon2d variant, low memory/passes, short or hardcoded nonce) |
 | [unsafe-vm-context](https://github.com/NodeSecure/js-x-ray/blob/master/docs/unsafe-vm-context.md) ⚠️ | No | Usage of dangerous vm.runInNewContext and (vm.Script(code,options)).runInContext |
 
 #### Information Severity

--- a/workspaces/js-x-ray/src/ProbeRunner.ts
+++ b/workspaces/js-x-ray/src/ProbeRunner.ts
@@ -30,7 +30,8 @@ import {
   isWeakScrypt,
   isUnsafePrehash,
   isWeakBcrypt,
-  isPasswordShucking
+  isPasswordShucking,
+  isWeakArgon2
 } from "./probes/crypto/index.ts";
 
 import type { TracedIdentifierReport } from "./VariableTracer.ts";
@@ -137,7 +138,8 @@ export class ProbeRunner {
     "crypto.weak-scrypt": isWeakScrypt,
     "crypto.unsafe-prehash": isUnsafePrehash,
     "crypto.weak-bcrypt": isWeakBcrypt,
-    "crypto.password-shucking": isPasswordShucking
+    "crypto.password-shucking": isPasswordShucking,
+    "crypto.weak-argon2": isWeakArgon2
   };
 
   constructor(

--- a/workspaces/js-x-ray/src/i18n/arabic.js
+++ b/workspaces/js-x-ray/src/i18n/arabic.js
@@ -24,7 +24,8 @@ export const sast_warnings = {
   unsafe_prehash: "استخدام bcryptjs مع كلمة مرور مُجزأة مسبقًا بخوارزمية غير آمنة (md5، sha1، sha256 أو sha512). يمكن للمهاجم تجاوز bcrypt عن طريق كسر التجزئة الوسيطة الأضعف.",
   weak_bcrypt: "استخدام دوال التجزئة bcryptjs (hash، hashSync، genSalt، genSaltSync) بعامل عمل أقل من 10، مما يجعل تجزئة كلمة المرور عرضة لهجمات القوة الغاشمة.",
   password_shucking: "استخدام bcryptjs حيث يتم تجزئة كلمة المرور أولًا بملخص تشفيري (md5، sha1، sha256 أو sha512) قبل تمريرها إلى bcrypt، مما يتيح هجمات hash shucking التي تتجاوز حماية bcrypt.",
-  unsafe_vm_context: "استخدام vm.runInContext() أو vm.Script.runInContext() حيث قد يتأثر كائن السياق بمدخلات غير موثوقة، مما يجعل بيئة الحماية عرضة للخطر."
+  unsafe_vm_context: "استخدام vm.runInContext() أو vm.Script.runInContext() حيث قد يتأثر كائن السياق بمدخلات غير موثوقة، مما يجعل بيئة الحماية عرضة للخطر.",
+  weak_argon2: "استخدام crypto.argon2() أو crypto.argon2Sync() بمعاملات غير آمنة: النسخة argon2d غير المخصصة لتجزئة كلمات المرور، أو nonce مضمّن في الشيفرة أو قصير (أقل من 16 بايت)، أو قيم memory و passes أقل من التركيبات التي توصي بها OWASP. هذه الإعدادات الضعيفة تُضعف أمان تجزئة كلمة المرور."
 };
 
 export default {

--- a/workspaces/js-x-ray/src/i18n/english.js
+++ b/workspaces/js-x-ray/src/i18n/english.js
@@ -24,7 +24,8 @@ export const sast_warnings = {
   unsafe_prehash: "Usage of bcryptjs with a password pre-hashed using an insecure digest algorithm (md5, sha1, sha256 or sha512). An attacker can bypass bcrypt by cracking the weaker intermediate hash.",
   weak_bcrypt: "Usage of bcryptjs hashing functions (hash, hashSync, genSalt, genSaltSync) with a work factor below 10, making password hashing susceptible to brute-force attacks.",
   password_shucking: "Usage of bcryptjs where the password is first hashed with a cryptographic digest (md5, sha1, sha256 or sha512) before being passed to bcrypt, enabling hash shucking attacks that bypass bcrypt protection.",
-  unsafe_vm_context: "Usage of vm.runInContext() or vm.Script.runInContext() where the context object may be influenced by untrusted input, making the sandbox vulnerable."
+  unsafe_vm_context: "Usage of vm.runInContext() or vm.Script.runInContext() where the context object may be influenced by untrusted input, making the sandbox vulnerable.",
+  weak_argon2: "Usage of crypto.argon2() or crypto.argon2Sync() with insecure parameters: the argon2d variant, which is not intended for password hashing, a hardcoded or short nonce (less than 16 bytes), or memory and passes values below the OWASP recommended combinations. These weak configurations compromise the security of password hashing."
 };
 
 export default {

--- a/workspaces/js-x-ray/src/i18n/french.js
+++ b/workspaces/js-x-ray/src/i18n/french.js
@@ -26,7 +26,8 @@ export const sast_warnings = {
   unsafe_prehash: "Utilisation de bcryptjs avec un mot de passe pré-haché par un algorithme non sécurisé (md5, sha1, sha256 ou sha512). Un attaquant peut contourner bcrypt en cassant le hachage intermédiaire plus faible.",
   weak_bcrypt: "Utilisation des fonctions de hachage bcryptjs (hash, hashSync, genSalt, genSaltSync) avec un facteur de travail inférieur à 10, rendant le hachage de mot de passe vulnérable aux attaques par brute force.",
   password_shucking: "Utilisation de bcryptjs où le mot de passe est d'abord haché avec un condensat cryptographique (md5, sha1, sha256 ou sha512) avant d'être passé à bcrypt, permettant des attaques de hash shucking qui contournent la protection bcrypt.",
-  unsafe_vm_context: "Utilisation de vm.runInContext() ou vm.Script.runInContext() où l'objet contexte peut être influencé par des entrées non fiables, rendant la sandbox vulnérable."
+  unsafe_vm_context: "Utilisation de vm.runInContext() ou vm.Script.runInContext() où l'objet contexte peut être influencé par des entrées non fiables, rendant la sandbox vulnérable.",
+  weak_argon2: "Utilisation de crypto.argon2() ou crypto.argon2Sync() avec des paramètres non sécurisés : la variante argon2d, qui n'est pas destinée au hachage de mot de passe, un nonce codé en dur ou trop court (moins de 16 octets), ou des valeurs memory et passes inférieures aux combinaisons recommandées par l'OWASP. Ces configurations faibles compromettent la sécurité du hachage de mot de passe."
 };
 
 export default {

--- a/workspaces/js-x-ray/src/i18n/korean.js
+++ b/workspaces/js-x-ray/src/i18n/korean.js
@@ -24,7 +24,8 @@ export const sast_warnings = {
   unsafe_prehash: "안전하지 않은 다이제스트 알고리즘(md5, sha1, sha256 또는 sha512)으로 사전 해시된 비밀번호와 함께 bcryptjs를 사용하는 경우입니다. 공격자는 더 약한 중간 해시를 크래킹하여 bcrypt를 우회할 수 있습니다.",
   weak_bcrypt: "작업 인수가 10 미만인 bcryptjs 해싱 함수(hash, hashSync, genSalt, genSaltSync)를 사용하는 경우로, 비밀번호 해싱이 무차별 대입 공격에 취약해집니다.",
   password_shucking: "비밀번호를 bcrypt에 전달하기 전에 암호화 다이제스트(md5, sha1, sha256 또는 sha512)로 먼저 해시하는 bcryptjs 사용 패턴으로, bcrypt 보호를 우회하는 해시 셔킹 공격이 가능해집니다.",
-  unsafe_vm_context: "vm.runInContext() 또는 vm.Script.runInContext()를 사용할 때 컨텍스트 객체가 신뢰할 수 없는 입력의 영향을 받아 샌드박스를 취약하게 만듭니다."
+  unsafe_vm_context: "vm.runInContext() 또는 vm.Script.runInContext()를 사용할 때 컨텍스트 객체가 신뢰할 수 없는 입력의 영향을 받아 샌드박스를 취약하게 만듭니다.",
+  weak_argon2: "안전하지 않은 매개변수로 crypto.argon2() 또는 crypto.argon2Sync()가 사용되었습니다. 비밀번호 해싱 용도가 아닌 argon2d 변형, 하드코딩되거나 짧은 nonce(16바이트 미만), 또는 OWASP 권장 조합에 미치지 못하는 memory·passes 값이 이에 해당합니다. 이러한 취약한 설정은 비밀번호 해싱의 보안을 손상시킵니다."
 };
 
 export default {

--- a/workspaces/js-x-ray/src/i18n/turkish.js
+++ b/workspaces/js-x-ray/src/i18n/turkish.js
@@ -24,7 +24,8 @@ export const sast_warnings = {
   unsafe_prehash: "bcryptjs'in güvensiz bir özet algoritmasıyla (md5, sha1, sha256 veya sha512) önceden hash'lenmiş bir parola ile kullanımı. Saldırgan, daha zayıf ara hash'i kırarak bcrypt'i atlayabilir.",
   weak_bcrypt: "bcryptjs hash işlevlerinin (hash, hashSync, genSalt, genSaltSync) 10'un altında bir iş faktörüyle kullanımı; parola hash'lemeyi kaba kuvvet saldırılarına karşı savunmasız kılar.",
   password_shucking: "bcryptjs'in parolayı bcrypt'e geçirmeden önce bir kriptografik özet (md5, sha1, sha256 veya sha512) ile ön hash'leyen kullanımı; bcrypt korumasını atlayan hash shucking saldırılarına olanak tanır.",
-  unsafe_vm_context: "vm.runInContext() veya vm.Script.runInContext() kullanımı; bağlam nesnesi güvenilmez girdilerden etkilenebilir ve sanal alanı savunmasız kılar."
+  unsafe_vm_context: "vm.runInContext() veya vm.Script.runInContext() kullanımı; bağlam nesnesi güvenilmez girdilerden etkilenebilir ve sanal alanı savunmasız kılar.",
+  weak_argon2: "crypto.argon2() veya crypto.argon2Sync() işlevlerinin güvensiz parametrelerle kullanımı: parola hash'leme için tasarlanmamış argon2d varyantı, koda gömülü veya kısa bir nonce (16 bayttan az) ya da OWASP'ın önerdiği kombinasyonların altında memory ve passes değerleri. Bu zayıf yapılandırmalar parola hash'lemenin güvenliğini tehlikeye atar."
 };
 
 export default {

--- a/workspaces/js-x-ray/src/probes/crypto/index.ts
+++ b/workspaces/js-x-ray/src/probes/crypto/index.ts
@@ -3,3 +3,4 @@ export { default as isWeakScrypt } from "./isWeakScrypt.ts";
 export { default as isUnsafePrehash } from "./isUnsafePrehash.ts";
 export { default as isWeakBcrypt } from "./isWeakBcrypt.ts";
 export { default as isPasswordShucking } from "./isPasswordShucking.ts";
+export { default as isWeakArgon2 } from "./isWeakArgon2.ts";

--- a/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
+++ b/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
@@ -3,6 +3,7 @@ import type { ESTree } from "meriyah";
 
 // Import Internal Dependencies
 import type { ProbeContext } from "../../ProbeRunner.ts";
+import type { VariableTracer } from "../../VariableTracer.ts";
 import { CALL_EXPRESSION_DATA } from "../../contants.ts";
 import { isStringLiteral, isNumericLiteral, isIdentifier } from "../../estree/types.ts";
 import { generateWarning } from "../../warnings.ts";
@@ -10,7 +11,7 @@ import { generateWarning } from "../../warnings.ts";
 /**
  * OWASP recommended Argon2 parameter combinations.
  * Each entry is [minMemory (KiB), passes] — every row provides an equal level
- * of defense, trading CPU against RAM.
+ * of defense, trading CPU against RAM. Sorted by ascending passes.
  *
  * @see https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
  */
@@ -34,20 +35,40 @@ const kOWASPRowsForArgon2i = kOWASPRows.filter(([, passes]) => passes >= 3);
 // @see https://www.rfc-editor.org/rfc/rfc9106.html#section-3.1
 const kMinNonceLength = 16;
 
-const kTracedFunctions = new Set(["crypto.argon2", "crypto.argon2Sync"]);
+const kTracedFunctions = ["crypto.argon2", "crypto.argon2Sync"];
 
-function isWeakParams(
+interface Argon2Params {
+  memory: number | null;
+  passes: number | null;
+  nonce: string | null;
+}
+
+/**
+ * Identify which parameter drags the call below the OWASP recommendations,
+ * or null when the combination is acceptable.
+ */
+function findWeakParam(
   algorithm: string,
   memory: number,
   passes: number
-): boolean {
+): "memory" | "passes" | null {
   const rows = algorithm === "argon2i" ? kOWASPRowsForArgon2i : kOWASPRows;
 
-  return !rows.some(
-    ([minMemory, minPasses]) => passes >= minPasses && memory >= minMemory
-  );
+  // Rows are sorted by ascending passes, and the memory requirement drops as
+  // passes grow. The last usable row is therefore the cheapest one available.
+  const row = rows.findLast(([, minPasses]) => passes >= minPasses);
+  if (row === undefined) {
+    return "passes";
+  }
+
+  return memory < row[0] ? "memory" : null;
 }
 
+/**
+ * Resolve the static name of a property key.
+ * Returns null for a computed key built from a variable, since its value is
+ * only known at runtime.
+ */
 function getPropertyName(
   prop: ESTree.Property
 ): string | null {
@@ -58,30 +79,78 @@ function getPropertyName(
   return isStringLiteral(prop.key) ? prop.key.value : null;
 }
 
-function extractNumericParam(
-  properties: ESTree.Property[],
-  name: string
-): number | null {
-  for (const prop of properties) {
-    if (getPropertyName(prop) === name && isNumericLiteral(prop.value)) {
-      return prop.value.value;
-    }
+/**
+ * Read a string out of a node, following identifiers assigned a string literal.
+ * TemplateLiteral assignments are ignored because the tracer stores them with
+ * their interpolations replaced by placeholders.
+ */
+function resolveString(
+  node: ESTree.Node | undefined,
+  tracer: VariableTracer
+): string | null {
+  if (isStringLiteral(node)) {
+    return node.value;
+  }
+  if (isIdentifier(node)) {
+    const literal = tracer.literalIdentifiers.get(node.name);
+
+    return literal?.type === "Literal" ? literal.value : null;
   }
 
   return null;
 }
 
-function extractStringParam(
-  properties: ESTree.Property[],
-  name: string
-): string | null {
-  for (const prop of properties) {
-    if (getPropertyName(prop) === name && isStringLiteral(prop.value)) {
-      return prop.value.value;
+/**
+ * Read a number out of a node, following identifiers assigned a numeric
+ * literal. The tracer stores every literal as a string, hence the conversion.
+ */
+function resolveNumber(
+  node: ESTree.Node | undefined,
+  tracer: VariableTracer
+): number | null {
+  if (isNumericLiteral(node)) {
+    return node.value;
+  }
+  if (isIdentifier(node)) {
+    const literal = tracer.literalIdentifiers.get(node.name);
+    if (literal?.type !== "Literal") {
+      return null;
     }
+    const value = Number(literal.value);
+
+    return Number.isNaN(value) ? null : value;
   }
 
   return null;
+}
+
+function extractParams(
+  properties: ESTree.ObjectExpression["properties"],
+  tracer: VariableTracer
+): Argon2Params {
+  const params: Argon2Params = { memory: null, passes: null, nonce: null };
+
+  for (const prop of properties) {
+    if (prop.type !== "Property") {
+      continue;
+    }
+
+    switch (getPropertyName(prop)) {
+      case "memory":
+        params.memory = resolveNumber(prop.value, tracer);
+        break;
+      case "passes":
+        params.passes = resolveNumber(prop.value, tracer);
+        break;
+      case "nonce":
+        params.nonce = resolveString(prop.value, tracer);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return params;
 }
 
 function validateNode(
@@ -95,7 +164,7 @@ function validateNode(
   }
 
   return [
-    kTracedFunctions.has(ctx.context![CALL_EXPRESSION_DATA]?.identifierOrMemberExpr)
+    kTracedFunctions.includes(ctx.context![CALL_EXPRESSION_DATA]?.identifierOrMemberExpr)
   ];
 }
 
@@ -112,47 +181,42 @@ function initialize(ctx: ProbeContext) {
 
 function main(node: ESTree.CallExpression, ctx: ProbeContext) {
   const { sourceFile } = ctx;
-  const algorithm = node.arguments.at(0);
-  const options = node.arguments.at(1);
+  const { tracer } = sourceFile;
 
-  if (!isStringLiteral(algorithm)) {
+  const algorithm = resolveString(node.arguments.at(0), tracer);
+  if (algorithm === null) {
     return;
   }
 
-  if (algorithm.value === "argon2d") {
+  if (algorithm === "argon2d") {
     sourceFile.warnings.push(
       generateWarning("crypto.weak-argon2", {
-        value: "weak-algorithm",
+        value: `weak-algorithm: ${algorithm}`,
         location: node.loc
       })
     );
   }
 
+  const options = node.arguments.at(1);
   if (options?.type !== "ObjectExpression") {
     return;
   }
 
-  const properties = options.properties.filter(
-    (prop): prop is ESTree.Property => prop.type === "Property"
-  );
+  const { memory, passes, nonce } = extractParams(options.properties, tracer);
 
-  const memory = extractNumericParam(properties, "memory");
-  const passes = extractNumericParam(properties, "passes");
+  if (memory !== null && passes !== null) {
+    const weakParam = findWeakParam(algorithm, memory, passes);
 
-  if (
-    memory !== null &&
-    passes !== null &&
-    isWeakParams(algorithm.value, memory, passes)
-  ) {
-    sourceFile.warnings.push(
-      generateWarning("crypto.weak-argon2", {
-        value: "low-params",
-        location: node.loc
-      })
-    );
+    if (weakParam !== null) {
+      sourceFile.warnings.push(
+        generateWarning("crypto.weak-argon2", {
+          value: `low-params: ${weakParam}`,
+          location: node.loc
+        })
+      );
+    }
   }
 
-  const nonce = extractStringParam(properties, "nonce");
   if (nonce !== null) {
     sourceFile.warnings.push(
       generateWarning("crypto.weak-argon2", {

--- a/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
+++ b/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
@@ -3,10 +3,12 @@ import type { ESTree } from "meriyah";
 
 // Import Internal Dependencies
 import type { ProbeContext } from "../../ProbeRunner.ts";
-import type { VariableTracer } from "../../VariableTracer.ts";
 import { CALL_EXPRESSION_DATA } from "../../contants.ts";
-import { isStringLiteral, isNumericLiteral, isIdentifier } from "../../estree/types.ts";
+import { isNode } from "../../estree/types.ts";
 import { generateWarning } from "../../warnings.ts";
+import { resolveNumericValue } from "./resolveNumericValue.ts";
+import { resolveStringValue } from "./resolveStringValue.ts";
+import { findPropertyMatch } from "../../estree/index.ts";
 
 /**
  * OWASP recommended Argon2 parameter combinations.
@@ -37,12 +39,6 @@ const kMinNonceLength = 16;
 
 const kTracedFunctions = ["crypto.argon2", "crypto.argon2Sync"];
 
-interface Argon2Params {
-  memory: number | null;
-  passes: number | null;
-  nonce: string | null;
-}
-
 /**
  * Identify which parameter drags the call below the OWASP recommendations,
  * or null when the combination is acceptable.
@@ -62,95 +58,6 @@ function findWeakParam(
   }
 
   return memory < row[0] ? "memory" : null;
-}
-
-/**
- * Resolve the static name of a property key.
- * Returns null for a computed key built from a variable, since its value is
- * only known at runtime.
- */
-function getPropertyName(
-  prop: ESTree.Property
-): string | null {
-  if (!prop.computed && isIdentifier(prop.key)) {
-    return prop.key.name;
-  }
-
-  return isStringLiteral(prop.key) ? prop.key.value : null;
-}
-
-/**
- * Read a string out of a node, following identifiers assigned a string literal.
- * TemplateLiteral assignments are ignored because the tracer stores them with
- * their interpolations replaced by placeholders.
- */
-function resolveString(
-  node: ESTree.Node | undefined,
-  tracer: VariableTracer
-): string | null {
-  if (isStringLiteral(node)) {
-    return node.value;
-  }
-  if (isIdentifier(node)) {
-    const literal = tracer.literalIdentifiers.get(node.name);
-
-    return literal?.type === "Literal" ? literal.value : null;
-  }
-
-  return null;
-}
-
-/**
- * Read a number out of a node, following identifiers assigned a numeric
- * literal. The tracer stores every literal as a string, hence the conversion.
- */
-function resolveNumber(
-  node: ESTree.Node | undefined,
-  tracer: VariableTracer
-): number | null {
-  if (isNumericLiteral(node)) {
-    return node.value;
-  }
-  if (isIdentifier(node)) {
-    const literal = tracer.literalIdentifiers.get(node.name);
-    if (literal?.type !== "Literal") {
-      return null;
-    }
-    const value = Number(literal.value);
-
-    return Number.isNaN(value) ? null : value;
-  }
-
-  return null;
-}
-
-function extractParams(
-  properties: ESTree.ObjectExpression["properties"],
-  tracer: VariableTracer
-): Argon2Params {
-  const params: Argon2Params = { memory: null, passes: null, nonce: null };
-
-  for (const prop of properties) {
-    if (prop.type !== "Property") {
-      continue;
-    }
-
-    switch (getPropertyName(prop)) {
-      case "memory":
-        params.memory = resolveNumber(prop.value, tracer);
-        break;
-      case "passes":
-        params.passes = resolveNumber(prop.value, tracer);
-        break;
-      case "nonce":
-        params.nonce = resolveString(prop.value, tracer);
-        break;
-      default:
-        break;
-    }
-  }
-
-  return params;
 }
 
 function validateNode(
@@ -183,7 +90,7 @@ function main(node: ESTree.CallExpression, ctx: ProbeContext) {
   const { sourceFile } = ctx;
   const { tracer } = sourceFile;
 
-  const algorithm = resolveString(node.arguments.at(0), tracer);
+  const algorithm = resolveStringValue(node.arguments.at(0), tracer.literalIdentifiers);
   if (algorithm === null) {
     return;
   }
@@ -202,7 +109,13 @@ function main(node: ESTree.CallExpression, ctx: ProbeContext) {
     return;
   }
 
-  const { memory, passes, nonce } = extractParams(options.properties, tracer);
+  const { properties } = options;
+
+  const memory = resolveNumericValue(findPropertyMatch(properties, ["memory"], isNode), tracer.literalIdentifiers);
+  const passes = resolveNumericValue(findPropertyMatch(properties, ["passes"], isNode), tracer.literalIdentifiers);
+  const nonce = resolveStringValue(findPropertyMatch(properties, ["nonce"], isNode), tracer.literalIdentifiers);
+
+  // const { memory, passes, nonce } = extractParams(options.properties, tracer);
 
   if (memory !== null && passes !== null) {
     const weakParam = findWeakParam(algorithm, memory, passes);

--- a/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
+++ b/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
@@ -1,0 +1,174 @@
+// Import Third-party Dependencies
+import type { ESTree } from "meriyah";
+
+// Import Internal Dependencies
+import type { ProbeContext } from "../../ProbeRunner.ts";
+import { CALL_EXPRESSION_DATA } from "../../contants.ts";
+import { isStringLiteral, isNumericLiteral, isIdentifier } from "../../estree/types.ts";
+import { generateWarning } from "../../warnings.ts";
+
+/**
+ * OWASP recommended Argon2 parameter combinations.
+ * Each entry is [minMemory (KiB), passes] — every row provides an equal level
+ * of defense, trading CPU against RAM.
+ *
+ * @see https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
+ */
+const kOWASPRows: [minMemory: number, passes: number][] = [
+  [47104, 1],
+  [19456, 2],
+  [12288, 3],
+  [9216, 4],
+  [7168, 5]
+];
+
+/**
+ * The two lowest-pass rows are flagged "(Do not use with Argon2i)" by OWASP.
+ * Argon2i is data-independent and therefore weaker against time-memory
+ * trade-off attacks, which additional passes mitigate.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9106.html#section-7.3
+ */
+const kOWASPRowsForArgon2i = kOWASPRows.filter(([, passes]) => passes >= 3);
+
+// @see https://www.rfc-editor.org/rfc/rfc9106.html#section-3.1
+const kMinNonceLength = 16;
+
+const kTracedFunctions = new Set(["crypto.argon2", "crypto.argon2Sync"]);
+
+function isWeakParams(
+  algorithm: string,
+  memory: number,
+  passes: number
+): boolean {
+  const rows = algorithm === "argon2i" ? kOWASPRowsForArgon2i : kOWASPRows;
+
+  return !rows.some(
+    ([minMemory, minPasses]) => passes >= minPasses && memory >= minMemory
+  );
+}
+
+function getPropertyName(
+  prop: ESTree.Property
+): string | null {
+  if (!prop.computed && isIdentifier(prop.key)) {
+    return prop.key.name;
+  }
+
+  return isStringLiteral(prop.key) ? prop.key.value : null;
+}
+
+function extractNumericParam(
+  properties: ESTree.Property[],
+  name: string
+): number | null {
+  for (const prop of properties) {
+    if (getPropertyName(prop) === name && isNumericLiteral(prop.value)) {
+      return prop.value.value;
+    }
+  }
+
+  return null;
+}
+
+function extractStringParam(
+  properties: ESTree.Property[],
+  name: string
+): string | null {
+  for (const prop of properties) {
+    if (getPropertyName(prop) === name && isStringLiteral(prop.value)) {
+      return prop.value.value;
+    }
+  }
+
+  return null;
+}
+
+function validateNode(
+  _node: ESTree.Node,
+  ctx: ProbeContext
+): [boolean, any?] {
+  const { tracer } = ctx.sourceFile;
+
+  if (!tracer.importedModules.has("crypto")) {
+    return [false];
+  }
+
+  return [
+    kTracedFunctions.has(ctx.context![CALL_EXPRESSION_DATA]?.identifierOrMemberExpr)
+  ];
+}
+
+function initialize(ctx: ProbeContext) {
+  const { tracer } = ctx.sourceFile;
+
+  for (const identifierOrMemberExpr of kTracedFunctions) {
+    tracer.trace(identifierOrMemberExpr, {
+      followConsecutiveAssignment: true,
+      moduleName: "crypto"
+    });
+  }
+}
+
+function main(node: ESTree.CallExpression, ctx: ProbeContext) {
+  const { sourceFile } = ctx;
+  const algorithm = node.arguments.at(0);
+  const options = node.arguments.at(1);
+
+  if (!isStringLiteral(algorithm)) {
+    return;
+  }
+
+  if (algorithm.value === "argon2d") {
+    sourceFile.warnings.push(
+      generateWarning("crypto.weak-argon2", {
+        value: "weak-algorithm",
+        location: node.loc
+      })
+    );
+  }
+
+  if (options?.type !== "ObjectExpression") {
+    return;
+  }
+
+  const properties = options.properties.filter(
+    (prop): prop is ESTree.Property => prop.type === "Property"
+  );
+
+  const memory = extractNumericParam(properties, "memory");
+  const passes = extractNumericParam(properties, "passes");
+
+  if (
+    memory !== null &&
+    passes !== null &&
+    isWeakParams(algorithm.value, memory, passes)
+  ) {
+    sourceFile.warnings.push(
+      generateWarning("crypto.weak-argon2", {
+        value: "low-params",
+        location: node.loc
+      })
+    );
+  }
+
+  const nonce = extractStringParam(properties, "nonce");
+  if (nonce !== null) {
+    sourceFile.warnings.push(
+      generateWarning("crypto.weak-argon2", {
+        value: nonce.length < kMinNonceLength ? "short-nonce" : "hardcoded-nonce",
+        location: node.loc
+      })
+    );
+  }
+}
+
+export default {
+  name: "isWeakArgon2",
+  nodeTypes: ["CallExpression"],
+  validateNode,
+  main,
+  initialize,
+  breakOnMatch: false,
+  context: {}
+};

--- a/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
+++ b/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
@@ -44,7 +44,7 @@ const kTracedFunctions = ["crypto.argon2", "crypto.argon2Sync"];
  * or null when the combination is acceptable.
  */
 function findWeakParam(
-  algorithm: string,
+  algorithm: string | null,
   memory: number,
   passes: number
 ): "memory" | "passes" | null {
@@ -89,51 +89,39 @@ function initialize(ctx: ProbeContext) {
 function main(node: ESTree.CallExpression, ctx: ProbeContext) {
   const { sourceFile } = ctx;
   const { tracer } = sourceFile;
+  const reasons: string[] = [];
 
   const algorithm = resolveStringValue(node.arguments.at(0), tracer.literalIdentifiers);
-  if (algorithm === null) {
-    return;
-  }
 
   if (algorithm === "argon2d") {
-    sourceFile.warnings.push(
-      generateWarning("crypto.weak-argon2", {
-        value: `weak-algorithm: ${algorithm}`,
-        location: node.loc
-      })
-    );
+    reasons.push(`weak-algorithm: ${algorithm}`);
   }
 
   const options = node.arguments.at(1);
-  if (options?.type !== "ObjectExpression") {
-    return;
-  }
 
-  const { properties } = options;
+  if (options?.type === "ObjectExpression") {
+    const { properties } = options;
+    const memory = resolveNumericValue(findPropertyMatch(properties, ["memory"], isNode), tracer.literalIdentifiers);
+    const passes = resolveNumericValue(findPropertyMatch(properties, ["passes"], isNode), tracer.literalIdentifiers);
+    const nonce = resolveStringValue(findPropertyMatch(properties, ["nonce"], isNode), tracer.literalIdentifiers);
 
-  const memory = resolveNumericValue(findPropertyMatch(properties, ["memory"], isNode), tracer.literalIdentifiers);
-  const passes = resolveNumericValue(findPropertyMatch(properties, ["passes"], isNode), tracer.literalIdentifiers);
-  const nonce = resolveStringValue(findPropertyMatch(properties, ["nonce"], isNode), tracer.literalIdentifiers);
+    if (memory !== null && passes !== null) {
+      const weakParam = findWeakParam(algorithm, memory, passes);
 
-  // const { memory, passes, nonce } = extractParams(options.properties, tracer);
+      if (weakParam !== null) {
+        reasons.push(`low-params: ${weakParam}`);
+      }
+    }
 
-  if (memory !== null && passes !== null) {
-    const weakParam = findWeakParam(algorithm, memory, passes);
-
-    if (weakParam !== null) {
-      sourceFile.warnings.push(
-        generateWarning("crypto.weak-argon2", {
-          value: `low-params: ${weakParam}`,
-          location: node.loc
-        })
-      );
+    if (nonce !== null) {
+      reasons.push(nonce.length < kMinNonceLength ? "short-nonce" : "hardcoded-nonce");
     }
   }
 
-  if (nonce !== null) {
+  if (reasons.length > 0) {
     sourceFile.warnings.push(
       generateWarning("crypto.weak-argon2", {
-        value: nonce.length < kMinNonceLength ? "short-nonce" : "hardcoded-nonce",
+        value: reasons.join(", "),
         location: node.loc
       })
     );

--- a/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
+++ b/workspaces/js-x-ray/src/probes/crypto/isWeakArgon2.ts
@@ -114,7 +114,7 @@ function main(node: ESTree.CallExpression, ctx: ProbeContext) {
     }
 
     if (nonce !== null) {
-      reasons.push(nonce.length < kMinNonceLength ? "short-nonce" : "hardcoded-nonce");
+      reasons.push(Buffer.byteLength(nonce) < kMinNonceLength ? "short-nonce" : "hardcoded-nonce");
     }
   }
 

--- a/workspaces/js-x-ray/src/probes/crypto/resolveStringValue.ts
+++ b/workspaces/js-x-ray/src/probes/crypto/resolveStringValue.ts
@@ -4,7 +4,8 @@ import type { LiteralIdentifier } from "../../VariableTracer.ts";
 
 /**
  * @description
- * Resolves a string literal, or an identifier tracked back to a string literal assignment
+ * Resolves a string literal, or an identifier tracked back to a string literal assignment.
+ * If the identifier is tracked back to a template literal, it will return null.
  */
 export function resolveStringValue(
   node: unknown,
@@ -14,7 +15,8 @@ export function resolveStringValue(
     return node.value;
   }
   if (isIdentifier(node)) {
-    return literalIdentifiers.get(node.name)?.value ?? null;
+    const literal = literalIdentifiers.get(node.name);
+    return literal?.type === "Literal" ? literal.value : null;
   }
 
   return null;

--- a/workspaces/js-x-ray/src/probes/crypto/resolveStringValue.ts
+++ b/workspaces/js-x-ray/src/probes/crypto/resolveStringValue.ts
@@ -16,6 +16,7 @@ export function resolveStringValue(
   }
   if (isIdentifier(node)) {
     const literal = literalIdentifiers.get(node.name);
+
     return literal?.type === "Literal" ? literal.value : null;
   }
 

--- a/workspaces/js-x-ray/src/probes/crypto/resolveStringValue.ts
+++ b/workspaces/js-x-ray/src/probes/crypto/resolveStringValue.ts
@@ -4,7 +4,7 @@ import type { LiteralIdentifier } from "../../VariableTracer.ts";
 
 /**
  * @description
- * Resolves a string literal, or an identifier tracked back to a string literal assignment.
+ * Resolves a string literal, or an identifier tracked back to a string literal assignment or a template literal.
  * If the identifier is tracked back to a template literal, it will return null.
  */
 export function resolveStringValue(

--- a/workspaces/js-x-ray/src/warnings.ts
+++ b/workspaces/js-x-ray/src/warnings.ts
@@ -16,7 +16,8 @@ export type OptionalWarningName =
   | "crypto.weak-scrypt"
   | "crypto.unsafe-prehash"
   | "crypto.weak-bcrypt"
-  | "crypto.password-shucking";
+  | "crypto.password-shucking"
+  | "crypto.weak-argon2";
 
 export type WarningName =
   | "parsing-error"
@@ -176,6 +177,11 @@ export const warnings = Object.freeze({
     i18n: "sast_warnings.unsafe_vm_context",
     severity: "Warning",
     experimental: false
+  },
+  "crypto.weak-argon2": {
+    i18n: "sast_warnings.weak_argon2",
+    severity: "Warning",
+    experimental: true
   }
 }) satisfies Record<WarningName, Pick<Warning, "experimental" | "i18n" | "severity">>;
 

--- a/workspaces/js-x-ray/test/probes/crypto/isWeakArgon2.spec.ts
+++ b/workspaces/js-x-ray/test/probes/crypto/isWeakArgon2.spec.ts
@@ -1,0 +1,314 @@
+// Import Node.js Dependencies
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+// Import Internal Dependencies
+import { AstAnalyser } from "../../../src/AstAnalyser.ts";
+
+function analyse(code: string) {
+  return new AstAnalyser({
+    optionalWarnings: ["crypto.weak-argon2"]
+  }).analyse(code);
+}
+
+describe("isWeakArgon2", () => {
+  describe("weak-algorithm", () => {
+    it("should warn when the argon2d variant is used, even with strong parameters", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2d", { memory: 47104, passes: 1, parallelism: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "crypto.weak-argon2");
+      assert.strictEqual(outputWarnings[0].value, "weak-algorithm");
+    });
+  });
+
+  describe("low-params", () => {
+    it("should warn when memory is far below the lowest OWASP row", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { memory: 8, passes: 1, parallelism: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params");
+    });
+
+    it("should warn with crypto.argon2Sync as well", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2Sync("argon2id", { memory: 8, passes: 1 });
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params");
+    });
+
+    it("should warn for argon2i with passes=1 regardless of how much memory is allocated", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2i", { memory: 47104, passes: 1, parallelism: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params");
+    });
+
+    it("should warn for argon2i with passes=2 (OWASP forbids that row for Argon2i)", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2i", { memory: 19456, passes: 2, parallelism: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params");
+    });
+
+    it("should warn for argon2i with passes=3 when memory is below 12288", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2i", { memory: 9216, passes: 3, parallelism: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params");
+    });
+
+    it("should warn when parameter keys are quoted string literals", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { "memory": 8, "passes": 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params");
+    });
+
+    it("should warn when parameter keys are computed string literals", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { ["memory"]: 8, ["passes"]: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params");
+    });
+
+    it("should not warn for argon2i when params meet the passes=3 row (m=12288)", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2i", { memory: 12288, passes: 3, parallelism: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn for argon2i when params meet the passes=5 row (m=7168)", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2i", { memory: 7168, passes: 5, parallelism: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn for argon2id with passes=1, which argon2i cannot use", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { memory: 47104, passes: 1, parallelism: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+
+  describe("short-nonce", () => {
+    it("should warn when nonce is a string literal shorter than 16 chars", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: "12345678" }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "short-nonce");
+    });
+  });
+
+  describe("hardcoded-nonce", () => {
+    it("should warn when nonce is a string literal of 16 chars or more", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: "0123456789abcdef" }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "hardcoded-nonce");
+    });
+  });
+
+  describe("combined warnings", () => {
+    it("should emit both low-params and short-nonce", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { memory: 8, passes: 1, nonce: "salt" }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.deepStrictEqual(
+        outputWarnings.map((warning) => warning.value).sort(),
+        ["low-params", "short-nonce"]
+      );
+    });
+
+    it("should emit both weak-algorithm and low-params", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2d", { memory: 8, passes: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.deepStrictEqual(
+        outputWarnings.map((warning) => warning.value).sort(),
+        ["low-params", "weak-algorithm"]
+      );
+    });
+  });
+
+  describe("values that cannot be resolved statically", () => {
+    it("should not warn when the options argument is a variable", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", options, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when the options argument is missing", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id");
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when the algorithm is a variable", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2(algorithm, { memory: 8, passes: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when passes is a variable", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { memory: 8, passes: iterations }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when a key is computed from a variable", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { [memory]: 8, [passes]: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when parameters come from a spread and cannot all be read", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { ...defaults, memory: 8 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+
+  describe("no warning (proper usage)", () => {
+    it("should not warn for argon2id with OWASP parameters and a random nonce", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", {
+          message: password,
+          nonce: crypto.randomBytes(16),
+          parallelism: 1,
+          tagLength: 32,
+          memory: 19456,
+          passes: 2
+        }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when nonce is a variable", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: salt }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when the crypto module is not imported", () => {
+      const code = `
+        argon2("argon2d", { memory: 8, passes: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn for an unrelated object exposing an argon2 method", () => {
+      const code = `
+        import crypto from 'crypto';
+        const fake = { argon2: () => {} };
+        fake.argon2("argon2d", { memory: 8, passes: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+
+  describe("optional warning behavior", () => {
+    it("should NOT report warnings when crypto.weak-argon2 is not enabled", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2d", { memory: 8, passes: 1, nonce: "salt" }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser().analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+  });
+});

--- a/workspaces/js-x-ray/test/probes/crypto/isWeakArgon2.spec.ts
+++ b/workspaces/js-x-ray/test/probes/crypto/isWeakArgon2.spec.ts
@@ -22,7 +22,19 @@ describe("isWeakArgon2", () => {
 
       assert.strictEqual(outputWarnings.length, 1);
       assert.strictEqual(outputWarnings[0].kind, "crypto.weak-argon2");
-      assert.strictEqual(outputWarnings[0].value, "weak-algorithm");
+      assert.strictEqual(outputWarnings[0].value, "weak-algorithm: argon2d");
+    });
+
+    it("should warn when the algorithm is an identifier assigned argon2d", () => {
+      const code = `
+        import crypto from 'crypto';
+        const algo = "argon2d";
+        crypto.argon2(algo, { memory: 47104, passes: 1, parallelism: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "weak-algorithm: argon2d");
     });
   });
 
@@ -35,7 +47,7 @@ describe("isWeakArgon2", () => {
       const { warnings: outputWarnings } = analyse(code);
 
       assert.strictEqual(outputWarnings.length, 1);
-      assert.strictEqual(outputWarnings[0].value, "low-params");
+      assert.strictEqual(outputWarnings[0].value, "low-params: memory");
     });
 
     it("should warn with crypto.argon2Sync as well", () => {
@@ -46,7 +58,7 @@ describe("isWeakArgon2", () => {
       const { warnings: outputWarnings } = analyse(code);
 
       assert.strictEqual(outputWarnings.length, 1);
-      assert.strictEqual(outputWarnings[0].value, "low-params");
+      assert.strictEqual(outputWarnings[0].value, "low-params: memory");
     });
 
     it("should warn for argon2i with passes=1 regardless of how much memory is allocated", () => {
@@ -57,7 +69,7 @@ describe("isWeakArgon2", () => {
       const { warnings: outputWarnings } = analyse(code);
 
       assert.strictEqual(outputWarnings.length, 1);
-      assert.strictEqual(outputWarnings[0].value, "low-params");
+      assert.strictEqual(outputWarnings[0].value, "low-params: passes");
     });
 
     it("should warn for argon2i with passes=2 (OWASP forbids that row for Argon2i)", () => {
@@ -68,7 +80,7 @@ describe("isWeakArgon2", () => {
       const { warnings: outputWarnings } = analyse(code);
 
       assert.strictEqual(outputWarnings.length, 1);
-      assert.strictEqual(outputWarnings[0].value, "low-params");
+      assert.strictEqual(outputWarnings[0].value, "low-params: passes");
     });
 
     it("should warn for argon2i with passes=3 when memory is below 12288", () => {
@@ -79,7 +91,20 @@ describe("isWeakArgon2", () => {
       const { warnings: outputWarnings } = analyse(code);
 
       assert.strictEqual(outputWarnings.length, 1);
-      assert.strictEqual(outputWarnings[0].value, "low-params");
+      assert.strictEqual(outputWarnings[0].value, "low-params: memory");
+    });
+
+    it("should warn when parameters are identifiers assigned numeric literals", () => {
+      const code = `
+        import crypto from 'crypto';
+        const memoryCost = 8;
+        const iterations = 1;
+        crypto.argon2("argon2id", { memory: memoryCost, passes: iterations }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params: memory");
     });
 
     it("should warn when parameter keys are quoted string literals", () => {
@@ -90,7 +115,7 @@ describe("isWeakArgon2", () => {
       const { warnings: outputWarnings } = analyse(code);
 
       assert.strictEqual(outputWarnings.length, 1);
-      assert.strictEqual(outputWarnings[0].value, "low-params");
+      assert.strictEqual(outputWarnings[0].value, "low-params: memory");
     });
 
     it("should warn when parameter keys are computed string literals", () => {
@@ -101,7 +126,7 @@ describe("isWeakArgon2", () => {
       const { warnings: outputWarnings } = analyse(code);
 
       assert.strictEqual(outputWarnings.length, 1);
-      assert.strictEqual(outputWarnings[0].value, "low-params");
+      assert.strictEqual(outputWarnings[0].value, "low-params: memory");
     });
 
     it("should not warn for argon2i when params meet the passes=3 row (m=12288)", () => {
@@ -159,6 +184,18 @@ describe("isWeakArgon2", () => {
       assert.strictEqual(outputWarnings.length, 1);
       assert.strictEqual(outputWarnings[0].value, "hardcoded-nonce");
     });
+
+    it("should warn when nonce is an identifier assigned a string literal", () => {
+      const code = `
+        import crypto from 'crypto';
+        const salt = "0123456789abcdef";
+        crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: salt }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "hardcoded-nonce");
+    });
   });
 
   describe("combined warnings", () => {
@@ -171,7 +208,7 @@ describe("isWeakArgon2", () => {
 
       assert.deepStrictEqual(
         outputWarnings.map((warning) => warning.value).sort(),
-        ["low-params", "short-nonce"]
+        ["low-params: memory", "short-nonce"]
       );
     });
 
@@ -184,7 +221,7 @@ describe("isWeakArgon2", () => {
 
       assert.deepStrictEqual(
         outputWarnings.map((warning) => warning.value).sort(),
-        ["low-params", "weak-algorithm"]
+        ["low-params: memory", "weak-algorithm: argon2d"]
       );
     });
   });
@@ -210,7 +247,7 @@ describe("isWeakArgon2", () => {
       assert.strictEqual(outputWarnings.length, 0);
     });
 
-    it("should not warn when the algorithm is a variable", () => {
+    it("should not warn when the algorithm is an unresolvable identifier", () => {
       const code = `
         import crypto from 'crypto';
         crypto.argon2(algorithm, { memory: 8, passes: 1 }, (err, tag) => {});
@@ -220,10 +257,20 @@ describe("isWeakArgon2", () => {
       assert.strictEqual(outputWarnings.length, 0);
     });
 
-    it("should not warn when passes is a variable", () => {
+    it("should not warn when passes is an unresolvable identifier", () => {
       const code = `
         import crypto from 'crypto';
         crypto.argon2("argon2id", { memory: 8, passes: iterations }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 0);
+    });
+
+    it("should not warn when nonce is an unresolvable identifier", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: salt }, (err, tag) => {});
       `;
       const { warnings: outputWarnings } = analyse(code);
 
@@ -263,16 +310,6 @@ describe("isWeakArgon2", () => {
           memory: 19456,
           passes: 2
         }, (err, tag) => {});
-      `;
-      const { warnings: outputWarnings } = analyse(code);
-
-      assert.strictEqual(outputWarnings.length, 0);
-    });
-
-    it("should not warn when nonce is a variable", () => {
-      const code = `
-        import crypto from 'crypto';
-        crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: salt }, (err, tag) => {});
       `;
       const { warnings: outputWarnings } = analyse(code);
 

--- a/workspaces/js-x-ray/test/probes/crypto/isWeakArgon2.spec.ts
+++ b/workspaces/js-x-ray/test/probes/crypto/isWeakArgon2.spec.ts
@@ -199,30 +199,48 @@ describe("isWeakArgon2", () => {
   });
 
   describe("combined warnings", () => {
-    it("should emit both low-params and short-nonce", () => {
+    it("should report low-params and short-nonce as a single warning", () => {
       const code = `
         import crypto from 'crypto';
         crypto.argon2("argon2id", { memory: 8, passes: 1, nonce: "salt" }, (err, tag) => {});
       `;
       const { warnings: outputWarnings } = analyse(code);
 
-      assert.deepStrictEqual(
-        outputWarnings.map((warning) => warning.value).sort(),
-        ["low-params: memory", "short-nonce"]
-      );
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params: memory, short-nonce");
     });
 
-    it("should emit both weak-algorithm and low-params", () => {
+    it("should report weak-algorithm and low-params as a single warning", () => {
       const code = `
         import crypto from 'crypto';
         crypto.argon2("argon2d", { memory: 8, passes: 1 }, (err, tag) => {});
       `;
       const { warnings: outputWarnings } = analyse(code);
 
-      assert.deepStrictEqual(
-        outputWarnings.map((warning) => warning.value).sort(),
-        ["low-params: memory", "weak-algorithm: argon2d"]
-      );
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "weak-algorithm: argon2d, low-params: memory");
+    });
+
+    it("should emit every failing check of a call in one warning", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2d", { memory: 8, passes: 1, nonce: "salt" }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "weak-algorithm: argon2d, low-params: memory, short-nonce");
+    });
+
+    it("should still report argon2d when the options cannot be read", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2d", options, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "weak-algorithm: argon2d");
     });
   });
 
@@ -247,10 +265,21 @@ describe("isWeakArgon2", () => {
       assert.strictEqual(outputWarnings.length, 0);
     });
 
-    it("should not warn when the algorithm is an unresolvable identifier", () => {
+    it("should still check the parameters when the algorithm is an unresolvable identifier", () => {
       const code = `
         import crypto from 'crypto';
         crypto.argon2(algorithm, { memory: 8, passes: 1 }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "low-params: memory");
+    });
+
+    it("should check the parameters against the general OWASP rows when the algorithm is unresolvable", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2(algorithm, { memory: 47104, passes: 1 }, (err, tag) => {});
       `;
       const { warnings: outputWarnings } = analyse(code);
 

--- a/workspaces/js-x-ray/test/probes/crypto/isWeakArgon2.spec.ts
+++ b/workspaces/js-x-ray/test/probes/crypto/isWeakArgon2.spec.ts
@@ -161,7 +161,7 @@ describe("isWeakArgon2", () => {
   });
 
   describe("short-nonce", () => {
-    it("should warn when nonce is a string literal shorter than 16 chars", () => {
+    it("should warn when nonce is a string literal shorter than 16 bytes", () => {
       const code = `
         import crypto from 'crypto';
         crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: "12345678" }, (err, tag) => {});
@@ -174,7 +174,7 @@ describe("isWeakArgon2", () => {
   });
 
   describe("hardcoded-nonce", () => {
-    it("should warn when nonce is a string literal of 16 chars or more", () => {
+    it("should warn when nonce is a string literal of 16 bytes or more", () => {
       const code = `
         import crypto from 'crypto';
         crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: "0123456789abcdef" }, (err, tag) => {});
@@ -190,6 +190,17 @@ describe("isWeakArgon2", () => {
         import crypto from 'crypto';
         const salt = "0123456789abcdef";
         crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: salt }, (err, tag) => {});
+      `;
+      const { warnings: outputWarnings } = analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].value, "hardcoded-nonce");
+    });
+
+    it("should measure the length of nonce in bytes (6 chars but 18 bytes)", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.argon2("argon2id", { memory: 47104, passes: 1, nonce: "가나다라마바" }, (err, tag) => {});
       `;
       const { warnings: outputWarnings } = analyse(code);
 

--- a/workspaces/js-x-ray/test/probes/crypto/resolveStringValue.spec.ts
+++ b/workspaces/js-x-ray/test/probes/crypto/resolveStringValue.spec.ts
@@ -64,4 +64,14 @@ describe("crypto.resolveStringValue", () => {
 
     assert.strictEqual(resolveStringValue(node, literalIdentifiers), "");
   });
+
+  test("returns null for an identifier tracked back to a template literal", () => {
+    const node = getExpression("foo");
+    const literalIdentifiers = new Map<string, LiteralIdentifier>([
+    /* eslint-disable-next-line no-template-curly-in-string */
+      ["foo", { value: "${0}", type: "TemplateLiteral" }]
+    ]);
+
+    assert.strictEqual(resolveStringValue(node, literalIdentifiers), null);
+  });
 });


### PR DESCRIPTION
Adds an optional weak-argon2 probe to detect insecure usage of crypto.argon2() and crypto.argon2Sync().

Detection targets:
- argon2d variant — RFC 9106 §1 describes Argon2d as suitable for cryptocurrencies and
  proof-of-work applications with no threats from side-channel timing attacks; §4 recommends
  Argon2id when in doubt
- Insufficient memory/passes — parameters matching none of the five OWASP recommended combinations
- argon2i with fewer than 3 passes — OWASP marks the two lowest-pass rows "(Do not use with
  Argon2i)"; RFC 9106 §7.3 notes that 3 passes is almost optimal for Argon2i
- Hardcoded nonce (string literal) — RFC 9106 §3.1: the salt SHOULD be unique for each password
- Short nonce (string literal shorter than 16 characters) — RFC 9106 §3.1: 16 bytes is
  RECOMMENDED for password hashing

Identifiers assigned a literal are resolved through the `VariableTracer`, so
`const algo = "argon2d"; crypto.argon2(algo, ...)` is reported as well.

Parameters that cannot be resolved statically (variables, spread elements, keys computed from
variables) are skipped rather than reported. `parallelism` is not checked, since raising it does
not reduce the total memory cost.

The warning is optional and disabled by default.

Partially addresses #506 (argon2 part)