### PR TITLE
fix(js-x-ray): match quoted property keys in findPropertyMatch

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/js-x-ray": patch
+---
+
+match quoted and computed string keys in findPropertyMatch, so `{ "cost": 1 }` and `{ ["cost"]: 1 }` are no longer skipped

--- a/workspaces/js-x-ray/src/estree/README.md
+++ b/workspaces/js-x-ray/src/estree/README.md
@@ -112,6 +112,27 @@ Will yield three components:
 </details>
 
 <details>
+<summary>findPropertyMatch< T extends ESTree.Node >(properties: ESTree.ObjectExpression["properties"], names: string[], predicate: (value: ESTree.Node) => value is T): T | null</summary>
+
+Returns the value of the first property whose key is in `names` and whose value matches `predicate`, or **null** if there is none.
+
+For example:
+
+```js
+{ cost: 1024, blockSize: 8 }
+```
+
+```ts
+findPropertyMatch(properties, ["cost", "N"], isNumericLiteral);
+```
+
+Will return the `Literal` node for `1024`.
+
+A key matches when its name is statically known. `{ cost: 1 }`, `{ "cost": 1 }`, and `{ ["cost"]: 1 }` will match `"cost"`, but `{ [cost]: 1 }` will not, because the real key is the *value* of `cost` at runtime.
+
+</details>
+
+<details>
 <summary>getCallExpressionArguments(node: ESTree.Node, options?: DefaultOptions): string[] | null</summary>
 
 Returns the literal arguments of a `CallExpression`.

--- a/workspaces/js-x-ray/src/estree/functions/findPropertyMatch.ts
+++ b/workspaces/js-x-ray/src/estree/functions/findPropertyMatch.ts
@@ -5,15 +5,7 @@ import type { ESTree } from "meriyah";
 import { isIdentifier, isStringLiteral } from "../types.ts";
 
 /**
- * Resolve the static name of a property key.
- *
- * A key is statically known when it is written as a plain identifier
- * (`{ cost: 1 }`) or as a string literal, quoted or computed
- * (`{ "cost": 1 }`, `{ ["cost"]: 1 }`) — all three describe the same key.
- *
- * limitation: a computed identifier (e.g. `{ [cost]: 1 }`) uses the *value* of
- * `cost` as the real key instead of the name "cost", so it is only known at
- * runtime. Returning null there avoids matching on the wrong property.
+ * Returns null for a computed identifier (`{ [cost]: 1 }`), whose key is only known at runtime.
  */
 function getPropertyName(prop: ESTree.Property): string | null {
   if (!prop.computed && isIdentifier(prop.key)) {

--- a/workspaces/js-x-ray/src/estree/functions/findPropertyMatch.ts
+++ b/workspaces/js-x-ray/src/estree/functions/findPropertyMatch.ts
@@ -2,13 +2,32 @@
 import type { ESTree } from "meriyah";
 
 // Import Internal Dependencies
-import { isIdentifier } from "../types.ts";
+import { isIdentifier, isStringLiteral } from "../types.ts";
+
+/**
+ * Resolve the static name of a property key.
+ *
+ * A key is statically known when it is written as a plain identifier
+ * (`{ cost: 1 }`) or as a string literal, quoted or computed
+ * (`{ "cost": 1 }`, `{ ["cost"]: 1 }`) — all three describe the same key.
+ *
+ * limitation: a computed identifier (e.g. `{ [cost]: 1 }`) uses the *value* of
+ * `cost` as the real key instead of the name "cost", so it is only known at
+ * runtime. Returning null there avoids matching on the wrong property.
+ */
+function getPropertyName(prop: ESTree.Property): string | null {
+  if (!prop.computed && isIdentifier(prop.key)) {
+    return prop.key.name;
+  }
+  if (isStringLiteral(prop.key)) {
+    return prop.key.value;
+  }
+
+  return null;
+}
 
 /**
  * Finds the first property whose key name is in `names` and whose value matches `predicate`.
- *
- * limitation: computed keys (e.g. `{ [cost]: 1 }`) use 'cost'` as the real key instead of the literal
- * name "cost", so excluding them avoids matching on the wrong property
  */
 export function findPropertyMatch<T extends ESTree.Node>(
   properties: ESTree.ObjectExpression["properties"],
@@ -16,11 +35,15 @@ export function findPropertyMatch<T extends ESTree.Node>(
   predicate: (value: ESTree.Node) => value is T
 ): T | null {
   for (const prop of properties) {
+    if (prop.type !== "Property") {
+      continue;
+    }
+
+    const key = getPropertyName(prop);
+
     if (
-      prop.type === "Property" &&
-      !prop.computed &&
-      isIdentifier(prop.key) &&
-      names.includes(prop.key.name) &&
+      key !== null &&
+      names.includes(key) &&
       predicate(prop.value)
     ) {
       return prop.value;

--- a/workspaces/js-x-ray/test/estree/findPropertyMatch.spec.ts
+++ b/workspaces/js-x-ray/test/estree/findPropertyMatch.spec.ts
@@ -99,4 +99,26 @@ describe("estree.findPropertyMatch", () => {
     assert.ok(result !== null);
     assert.strictEqual(result.value, 0);
   });
+
+  test("matches a key written as a quoted string literal", () => {
+    const properties = getProperties("{ 'cost' : 100 }");
+    const result = findPropertyMatch(properties, ["cost"], isNumericLiteral);
+
+    assert.ok(result !== null);
+    assert.strictEqual(result.value, 100);
+  });
+
+  test("matches a computed key holding a string literal", () => {
+    const properties = getProperties(`{ ["cost"]: 100 }`);
+    const result = findPropertyMatch(properties, ["cost"], isNumericLiteral);
+
+    assert.ok(result !== null);
+    assert.strictEqual(result.value, 100);
+  });
+
+  test("returns null when a quoted key does not match any name", () => {
+    const properties = getProperties(`{ "notCost": 100 }`);
+
+    assert.strictEqual(findPropertyMatch(properties, ["cost"], isNumericLiteral), null);
+  });
 });

--- a/workspaces/js-x-ray/test/probes/crypto/isWeakScrypt.spec.ts
+++ b/workspaces/js-x-ray/test/probes/crypto/isWeakScrypt.spec.ts
@@ -67,6 +67,20 @@ describe("isWeakScrypt", () => {
       assert.strictEqual(outputWarnings[0].value, "low-cost");
     });
 
+    it("should warn when the cost option key is written as a quoted string literal", () => {
+      const code = `
+        import crypto from 'crypto';
+        crypto.scrypt(password, salt, 64, { "cost": 1024 }, (err, key) => {});
+      `;
+      const { warnings: outputWarnings } = new AstAnalyser({
+        optionalWarnings: ["crypto.weak-scrypt"]
+      }).analyse(code);
+
+      assert.strictEqual(outputWarnings.length, 1);
+      assert.strictEqual(outputWarnings[0].kind, "crypto.weak-scrypt");
+      assert.strictEqual(outputWarnings[0].value, "low-cost");
+    });
+
     it("should warn when cost option is set without sufficient parallelization (N=16384, default p=1)", () => {
       const code = `
         import crypto from 'crypto';


### PR DESCRIPTION
`findPropertyMatch` requires `!prop.computed && isIdentifier(prop.key)`, so a property key written as a string literal is skipped even though its name is statically known.

```js
crypto.scrypt(password, salt, 64, {  cost : 1024 }, cb)   // reported
crypto.scrypt(password, salt, 64, { "cost": 1024 }, cb)   // not reported
```

Both build the same object at runtime, and `cost: 1024` is well below the lowest OWASP row, so the second one was a miss.

The key name is now resolved through a small `getPropertyName` helper:

| key | resolved |
| --- | --- |
| `{ cost: 1 }` | `"cost"` |
| `{ "cost": 1 }` | `"cost"` |
| `{ ["cost"]: 1 }` | `"cost"` |
| `{ [cost]: 1 }` | `null` |

The last row stays excluded. The real key is the *value* of `cost` at runtime, so it is not statically known. The existing test covering it still passes.

`isWeakScrypt` is the only probe using the helper today, so it is the only behaviour change. Added a regression test there, plus three cases on the helper itself.

Split out of #699 as suggested on Discord, so it can land independently.